### PR TITLE
Refactor: Event 및 Scheduler 구현 & 테스트 

### DIFF
--- a/src/main/java/com/example/springserver/MockDataGenerator.java
+++ b/src/main/java/com/example/springserver/MockDataGenerator.java
@@ -66,12 +66,12 @@ public class MockDataGenerator implements ApplicationRunner {
         for (int i = 0; i < 10; i++) {
             admin();
         }
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 10; i++) {
             elder();
         }
 
         // 3. 요양보호사 데이터 생성
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 10; i++) {
             careGiver();
         }
 
@@ -82,17 +82,17 @@ public class MockDataGenerator implements ApplicationRunner {
         }
 
         // 5. 구직 조건, 근무지 데이터 생성
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 1; i++) {
             jobCondition(i+1);
             workLocation();
         }
 
         // 6. 구인 조건과 시간 데이터 생성
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 1; i++) {
             recruitCondition(i+1);
             care(i+1);
         }
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 1; i++) {
             recruitTime();
             recruitLocation();
         }

--- a/src/main/java/com/example/springserver/ScoreDataInitializer.java
+++ b/src/main/java/com/example/springserver/ScoreDataInitializer.java
@@ -18,10 +18,15 @@ public class ScoreDataInitializer implements ApplicationRunner {
     private final ScoreCalculationService scoreCalculationService;
     private final RecruitService recruitService;
 
+    /**
+     * MockDataGenerator 쓰면 이게 점수가 안뜨잖아요 Event감지가 안되어서..
+     * 그것을 막기위해서 처음에 실행되는 Method예요 존재하는 모든 조합에 대해초반 계산을 시작하게 해요
+     * 필요에 의해 주석해제, 주석 할수 있죠
+     */
     @Override
     public void run(ApplicationArguments args) throws Exception {
-        List<Long> list = recruitService.findAllRecCond();
-        for(Long rcId : list)
-            scoreCalculationService.recalculateScoresForRecruit(rcId);
+//        List<Long> list = recruitService.findAllRecCond();
+//        for(Long rcId : list)
+//            scoreCalculationService.recalculateScoresForRecruit(rcId);
     }
 }

--- a/src/main/java/com/example/springserver/ScoreDataInitializer.java
+++ b/src/main/java/com/example/springserver/ScoreDataInitializer.java
@@ -1,0 +1,27 @@
+package com.example.springserver;
+
+import com.example.springserver.domain.center.service.RecruitService;
+import com.example.springserver.service.score.service.ScoreCalculationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class ScoreDataInitializer implements ApplicationRunner {
+
+    private final ScoreCalculationService scoreCalculationService;
+    private final RecruitService recruitService;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        List<Long> list = recruitService.findAllRecCond();
+        for(Long rcId : list)
+            scoreCalculationService.recalculateScoresForRecruit(rcId);
+    }
+}

--- a/src/main/java/com/example/springserver/SpringServerApplication.java
+++ b/src/main/java/com/example/springserver/SpringServerApplication.java
@@ -3,9 +3,11 @@ package com.example.springserver;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class SpringServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/springserver/domain/caregiver/entity/JobCondition.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/entity/JobCondition.java
@@ -142,7 +142,7 @@ public class JobCondition extends BaseEntity {
     private Caregiver caregiver;
 
     @NotNull
-    @OneToMany(mappedBy = "jobCondition",fetch = FetchType.LAZY,cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "jobCondition",fetch = FetchType.LAZY,cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WorkLocation> workLocations = new ArrayList<>();
 
     public JobCondition(ScheduleAvailability flexibleSchedule, Integer desiredHourlyWage, ScheduleAvailability selfFeeding,
@@ -179,7 +179,7 @@ public class JobCondition extends BaseEntity {
         this.caregiver = caregiver;
     }
 
-    public void updateInfo(JobConditionReqDto req){
+    public void updateInfo(JobConditionReqDto req) {
         this.flexibleSchedule = req.getFlexibleSchedule();
         this.desiredHourlyWage = req.getDesiredHourlyWage();
         this.selfFeeding = req.getSelfFeeding();

--- a/src/main/java/com/example/springserver/domain/caregiver/entity/JobCondition.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/entity/JobCondition.java
@@ -137,7 +137,7 @@ public class JobCondition extends BaseEntity {
     private Long endTime;
 
     @NotNull
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @OneToOne(fetch = FetchType.EAGER, optional = false)
     @JoinColumn(name = "caregiver", nullable = false)
     private Caregiver caregiver;
 

--- a/src/main/java/com/example/springserver/domain/caregiver/repository/JobConditionRepository.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/repository/JobConditionRepository.java
@@ -4,6 +4,7 @@ import com.example.springserver.domain.caregiver.entity.Caregiver;
 import com.example.springserver.domain.caregiver.entity.JobCondition;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,24 +13,11 @@ public interface JobConditionRepository extends JpaRepository<JobCondition,Long>
     Optional<JobCondition> findByCaregiver(Caregiver caregiver);
 
     @Query(value = """
-            SELECT DISTINCT jc.*
+        SELECT jc.*
         FROM job_condition jc
-        JOIN work_location wl\s
-          ON jc.job_condition_id = wl.job_condition_id
-        JOIN recruit_condition rc\s
-          ON rc.location_id = wl.location_id
-        JOIN recruit_time rt2\s
-          ON rt2.recruit_condition_id = rc.recruit_condition_id
-        JOIN recruit_time rt3\s
-          ON rt3.recruit_condition_id = rc.recruit_condition_id
-          AND rt3.dayOfWeek = rt2.dayOfWeek
-        WHERE\s
-          -- 요일 조건: job_condition의 day_of_week와 recruit_time의 요일 플래그 비교
-          (jc.day_of_week & rt2.dayOfWeek) != 0
-          -- 시간 조건: job_condition의 근무시간이 recruit_time의 시작시간과 겹치는지 확인
-          AND jc.start_time < rt3.startTime\s
-          AND jc.end_time > rt3.startTime;""", nativeQuery = true)
-    List<JobCondition> findAllRecommendedListByElder(Long id);
+        JOIN work_location wl ON wl.job_condition_id = jc.job_condition_id
+        WHERE wl.location_id = :rcLocationId""", nativeQuery = true)
+    Optional<List<JobCondition>> findAllByRecommendedListByElder(@Param("rcLocationId") Long rcLocationId);
 
     // Mock 데이터 생성용
     @Query(value = "SELECT * FROM job_condition order by RAND() limit 1",nativeQuery = true)

--- a/src/main/java/com/example/springserver/domain/caregiver/service/JobConditionService.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/service/JobConditionService.java
@@ -2,6 +2,7 @@ package com.example.springserver.domain.caregiver.service;
 
 
 import com.example.springserver.domain.caregiver.converter.JobConditionConverter;
+import com.example.springserver.domain.caregiver.dto.request.JobConditionRequestDto;
 import com.example.springserver.domain.caregiver.dto.request.JobConditionRequestDto.JobConditionReqDto;
 import com.example.springserver.domain.caregiver.dto.response.JobConditionResponseDto;
 import com.example.springserver.domain.caregiver.dto.response.JobConditionResponseDto.DetailJobConditionResponseDTO;
@@ -24,7 +25,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -38,6 +41,11 @@ public class JobConditionService {
     private final WorkLocationRepository workLocationRepository;
     private final ApplicationEventPublisher eventPublisher;
 
+    /*
+    JC 변경 메서드입니다.
+    여기서 eventPublisher 통해 JobcondChangedEvent 호출됩니다.
+    이제 EventListener 가시면됩니다. -> ScoreRecalculateEventListener
+     */
     @Transactional
     public JobConditionResponseDTO createOrUpdateJobCondition(CustomUserDetails user, JobConditionReqDto request) {
         Caregiver caregiver = commonService.getById(user);
@@ -89,23 +97,34 @@ public class JobConditionService {
 
     @Transactional
     public JobConditionResponseDTO updateJobCondition(Caregiver user, JobConditionReqDto request) {
-
         JobCondition jobCondition = getJobCondition(user);
 
-        workLocationRepository.deleteByJobCondition(jobCondition);
-        workLocationRepository.flush();
+        Set<Long> updatedIds = new HashSet<>();
 
-        jobCondition.getWorkLocations().clear();
+        for (JobConditionRequestDto.LocationRequestDTO dto : request.getLocationRequestDTOList()) {
+            Location location = locationService.findById(dto.getLocationId());
+
+            if (dto.getWorkLocationId() != null) {
+                WorkLocation existing = jobCondition.getWorkLocations().stream()
+                        .filter(wl -> wl.getId().equals(dto.getWorkLocationId()))
+                        .findFirst()
+                        .orElseThrow(() -> new GlobalException(ErrorCode.WORK_LOCATION_NOT_FOUND));
+
+                existing.setLocationId(location);
+                updatedIds.add(existing.getId());
+            }
+            else {
+                WorkLocation newLocation = WorkLocation.builder()
+                        .locationId(location)
+                        .jobCondition(jobCondition)
+                        .build();
+                jobCondition.addWokLocation(newLocation);
+            }
+        }
+
+        jobCondition.getWorkLocations().removeIf(wl -> !updatedIds.contains(wl.getId()));
 
         jobCondition.updateInfo(request);
-
-        jobCondition = jobConditionRepository.save(jobCondition);
-
-        saveLocations(request, jobCondition);
-
-        jobCondition = jobConditionRepository.findById(jobCondition.getId())
-                .orElseThrow(() -> new GlobalException(ErrorCode.JOB_CONDITION_NOT_FOUND));
-
         return toJobConditionResponseDto(jobCondition);
     }
 

--- a/src/main/java/com/example/springserver/domain/caregiver/service/JobConditionService.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/service/JobConditionService.java
@@ -16,8 +16,10 @@ import com.example.springserver.global.apiPayload.format.ErrorCode;
 import com.example.springserver.global.apiPayload.format.GlobalException;
 import com.example.springserver.global.security.util.CustomUserDetails;
 import com.example.springserver.global.utils.FormatUtils;
+import com.example.springserver.service.event.JobConditionChangedEvent;
 import com.example.springserver.service.location.LocationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,14 +36,16 @@ public class JobConditionService {
     private final LocationService locationService;
     private final JobConditionRepository jobConditionRepository;
     private final WorkLocationRepository workLocationRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public JobConditionResponseDTO createOrUpdateJobCondition(CustomUserDetails user, JobConditionReqDto request) {
         Caregiver caregiver = commonService.getById(user);
-
-        return jobConditionRepository.findByCaregiver(caregiver)
+        JobConditionResponseDTO jobConditionResponseDTO = jobConditionRepository.findByCaregiver(caregiver)
                 .map(existingJobCondition -> updateJobCondition(caregiver, request)) // 존재하면 업데이트
-                .orElseGet(() -> createJobCondition(caregiver, request)); // 없으면 새로 생성
+                .orElseGet(() -> createJobCondition(caregiver, request));// 없으면 새로 생성
+        eventPublisher.publishEvent(new JobConditionChangedEvent(this,jobConditionResponseDTO.getJobConditionId()));
+        return jobConditionResponseDTO;
     }
 
     @Transactional

--- a/src/main/java/com/example/springserver/domain/center/controller/RecruitController.java
+++ b/src/main/java/com/example/springserver/domain/center/controller/RecruitController.java
@@ -41,7 +41,7 @@ public class RecruitController {
     @PutMapping("/{recruit_id}")
     public void updateRecruit(@PathVariable Long center_id, @PathVariable Long elder_id, @PathVariable Long recruit_id,
                                               @RequestBody RequestDto requestDto) {
-        recruitService.updateRecruitCondition(center_id, recruit_id, elder_id, requestDto);
+        recruitService.updateRecruitCondition(center_id, elder_id, recruit_id, requestDto);
     }
 
     // 구인 요양보호사 조건 삭제

--- a/src/main/java/com/example/springserver/domain/center/entity/RecruitCondition.java
+++ b/src/main/java/com/example/springserver/domain/center/entity/RecruitCondition.java
@@ -28,7 +28,7 @@ public class RecruitCondition extends BaseEntity {
     @JoinColumn(name = "elder_id", nullable = false)
     private Elder elder;
 
-    @OneToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "location_id", nullable = false)
     private Location recruitLocation;
 

--- a/src/main/java/com/example/springserver/domain/center/entity/RecruitCondition.java
+++ b/src/main/java/com/example/springserver/domain/center/entity/RecruitCondition.java
@@ -28,7 +28,7 @@ public class RecruitCondition extends BaseEntity {
     @JoinColumn(name = "elder_id", nullable = false)
     private Elder elder;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "location_id", nullable = false)
     private Location recruitLocation;
 

--- a/src/main/java/com/example/springserver/domain/center/entity/RecruitTime.java
+++ b/src/main/java/com/example/springserver/domain/center/entity/RecruitTime.java
@@ -19,7 +19,7 @@ public class RecruitTime {
     @Column(nullable = false)
     private Long recruitTimeId;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     @JoinColumn(name = "recruit_condition_id")
     private RecruitCondition recruitCondition;
 

--- a/src/main/java/com/example/springserver/domain/center/repository/MatchRepository.java
+++ b/src/main/java/com/example/springserver/domain/center/repository/MatchRepository.java
@@ -11,10 +11,8 @@ import java.util.List;
 
 public interface MatchRepository extends JpaRepository<Match,Long> {
 
-    List<Match> findAllByJobCondition(JobCondition jobCondition);
-
     @Query("SELECT DISTINCT m FROM Match m "
-            + "JOIN FETCH m.requirementCondition rc "
+            + "JOIN FETCH m.recruitCondition rc "
             + "JOIN FETCH rc.elder e "
             + "LEFT JOIN FETCH rc.recruitTimes rt "
             + "WHERE m.jobCondition = :jobCondition AND m.status IN (:statuses)")
@@ -24,21 +22,23 @@ public interface MatchRepository extends JpaRepository<Match,Long> {
     );
 
     @Query(value = "SELECT `match`.status FROM `match` " +
-            "WHERE requirement_condition_id = :rc " +
+            "WHERE recruit_condition_id = :rc " +
             "AND job_condition_id = :jc " +
             "AND `match`.status IN ('WAITING', 'TUNING')" +
             "LIMIT 1",
             nativeQuery = true)
-    MatchStatus findAllByJobConditionAndRecruitCondition(@Param("rc") Long rc, @Param("jc") Long jc);
+    MatchStatus findByJobCondition_IdAndRecruitCondition_Id(@Param("rc") Long rc, @Param("jc") Long jc);
 
     @Query(value = "SELECT * FROM `match` " +
-            "WHERE requirement_condition_id = :rc " +
+            "WHERE recruit_condition_id = :rc " +
             "AND job_condition_id = :jc " +
             "AND `match`.status IN ('TUNING')" +
             "LIMIT 1",
             nativeQuery = true)
     Match findByJcAndRC(@Param("jc") Long jc, @Param("rc") Long rc);
 
-    @Query("SELECT m FROM Match m WHERE m.requirementCondition.elder.center.centerId = :centerId")
+    @Query("SELECT m FROM Match m WHERE m.recruitCondition.elder.center.centerId = :centerId")
     List<Match> findByCenterId(@Param("centerId") Long centerId);
+
+    List<Match> findAllByRecruitCondition_RecruitConditionId(Long recruitConditionId);
 }

--- a/src/main/java/com/example/springserver/domain/center/repository/RecruitCondRepository.java
+++ b/src/main/java/com/example/springserver/domain/center/repository/RecruitCondRepository.java
@@ -19,4 +19,9 @@ public interface RecruitCondRepository extends JpaRepository<RecruitCondition, L
     // Mock 데이터 생성용
     @Query(value = "SELECT * FROM recruit_condition order by RAND() limit 1",nativeQuery = true)
     Optional<RecruitCondition> findRandom();
+
+    List<RecruitCondition> findAllByRecruitLocation_LocationIdIn(List<Long> locationIds);
+
+    @Query(value = "SELECT recruit_condition_id FROM recruit_condition",nativeQuery = true)
+    List<Long> findAllRecuitIds();
 }

--- a/src/main/java/com/example/springserver/domain/center/service/RecruitService.java
+++ b/src/main/java/com/example/springserver/domain/center/service/RecruitService.java
@@ -12,8 +12,10 @@ import com.example.springserver.domain.location.entity.Location;
 import com.example.springserver.global.apiPayload.format.*;
 import com.example.springserver.global.validation.validator.RecruitLaborLawValidator;
 import com.example.springserver.repository.location.LocationRepository;
+import com.example.springserver.service.event.RecruitConditionChangedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,8 +34,13 @@ public class RecruitService {
     private final LocationRepository locationRepository;
     private final CenterRepository centerRepository;
     private final ElderRepository elderRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     private final RecruitLaborLawValidator recruitLaborLawValidator;
+
+    public List<Long> findAllRecCond(){
+        return recruitCondRepository.findAllRecuitIds();
+    }
 
     public List<RecruitCondition> getRecruitConditionList(Long centerId, Long elderId) {
         isValidCenter(elderId, centerId);
@@ -48,13 +55,14 @@ public class RecruitService {
 
     @Transactional
     public ResponseDto createRecruit(Long centerId, Long elderId, RequestDto createRequestDto) {
-
         // 요청 데이터 검증
         isValidCenter(elderId, centerId);
         isValidRecruitCondition(createRequestDto);
 
         Elder elder = getElderById(elderId);
         RecruitCondition recruitCondition = saveOrUpdateRecruitCondition(null, elder, createRequestDto);
+
+        applicationEventPublisher.publishEvent(new RecruitConditionChangedEvent(this,recruitCondition.getRecruitConditionId()));
 
         return RecruitConverter.toConditionResponseDto(recruitCondition);
     }
@@ -68,6 +76,8 @@ public class RecruitService {
 
         Elder elder = getElderById(elderId);
         saveOrUpdateRecruitCondition(recruitConditionId, elder, requestDto);
+
+        applicationEventPublisher.publishEvent(new RecruitConditionChangedEvent(this,recruitConditionId));
     }
 
     @Transactional

--- a/src/main/java/com/example/springserver/domain/match/controller/MatchController.java
+++ b/src/main/java/com/example/springserver/domain/match/controller/MatchController.java
@@ -49,20 +49,6 @@ public class MatchController {
         return MatchConverter.toRequestListRes(matchService.getRequests(user));
     }
 
-    @Operation(summary = "어르신별 추천된 요양보호사리스트 조회", description = "Get")
-    @GetMapping("/recommends/{recruit_condition_id}")
-    public MatchRecommendList getRecommendListByElder(@AuthenticationPrincipal CustomUserDetails user,
-                                                      @PathVariable("recruit_condition_id") Long request) {
-        return MatchConverter.toRecommendList(matchService.getRecommendList(request));
-    }
-
-    @Operation(summary = "요양보호사에게 근무요청", description = "Post")
-    @PostMapping("/recommends/{job_condition_id}/{recruit_condition_id}")
-    public MatchCreateDto createMatchRequest(@AuthenticationPrincipal CustomUserDetails user,
-                                                              @PathVariable("job_condition_id") Long jc,
-                                                              @PathVariable("recruit_condition_id") Long rc) {
-        return matchService.createMatch(user,jc,rc);
-    }
 
     @Operation(summary = "추천결과 조회 및 상세조회 API", description = "Post")
     @GetMapping("/recommends/{job_condition_id}/{recruit_condition_id}")
@@ -88,4 +74,20 @@ public class MatchController {
         List<Match> centerMatchingList = matchService.getCenterMatchingList(centerId);
         return MatchConverter.toMatchDtoList(centerMatchingList);
     }
+
+
+    @Operation(summary = "요양보호사에게 근무요청", description = "Post")
+    @PostMapping("/recommends/{job_condition_id}/{recruit_condition_id}")
+    public MatchCreateDto createMatchRequest(@AuthenticationPrincipal CustomUserDetails user,
+                                             @PathVariable("job_condition_id") Long jc,
+                                             @PathVariable("recruit_condition_id") Long rc) {
+        return matchService.createMatch(user,jc,rc);
+    }
+
+//    @Operation(summary = "어르신별 추천된 요양보호사리스트 조회", description = "Get")
+//    @GetMapping("/recommends/{recruit_condition_id}")
+//    public MatchRecommendList getRecommendListByElder(@AuthenticationPrincipal CustomUserDetails user,
+//                                                      @PathVariable("recruit_condition_id") Long rcId) {
+//        return MatchConverter.toRecommendList(matchService.getRecommendList(rcId));
+//    }
 }

--- a/src/main/java/com/example/springserver/domain/match/converter/MatchConverter.java
+++ b/src/main/java/com/example/springserver/domain/match/converter/MatchConverter.java
@@ -94,12 +94,12 @@ public class MatchConverter {
                 .matchId(match.getId())
                 .status(match.getStatus())
                 .requirementCondition(
-                        RecruitConverter.toConditionResponseDto(match.getRequirementCondition())
+                        RecruitConverter.toConditionResponseDto(match.getRecruitCondition())
                         ) // recruitCondition -> dto 변환 필요
                 .jobCondition(
                         JobConditionConverter.toJobConditionResponseDto(match.getJobCondition())
                         )
-                .elderInfoDto(ElderConverter.toMatchElderDto(match.getRequirementCondition().getElder())) // elder -> dto 변환 필요
+                .elderInfoDto(ElderConverter.toMatchElderDto(match.getRecruitCondition().getElder())) // elder -> dto 변환 필요
                 .careGiverInfoDto(CaregiverConverter.toMatchCaregiverDto(match.getJobCondition().getCaregiver())) // careGiver -> dto 변환 필요
                 .deletedAt(match.getDeletedAt())
                 .version(match.getVersion())

--- a/src/main/java/com/example/springserver/domain/match/service/MatchService.java
+++ b/src/main/java/com/example/springserver/domain/match/service/MatchService.java
@@ -62,13 +62,6 @@ public class MatchService {
     private final RecruitCondRepository recruitCondRepository;
     private final MatchRepository matchRepository;
     private final AdminRepository adminRepository;
-    private final ElderRepository elderRepository;
-    private final LocationService locationService;
-
-
-    @Autowired
-    private ModelMapper modelMapper;
-
 
     public List<MatchedStatus> getCalenderList(CustomUserDetails user) {
         Caregiver caregiver = commonService.getById(user);
@@ -81,8 +74,8 @@ public class MatchService {
 
         return allByJobConditionWithStatus.stream()
                 .map(match -> {
-                    Elder elder = match.getRequirementCondition().getElder();
-                    RecruitCondition rc = match.getRequirementCondition();
+                    Elder elder = match.getRecruitCondition().getElder();;
+                    RecruitCondition rc = match.getRecruitCondition();
                     Center center = match.getCenter();
 
                     List<RecruitTime> recruitTimes = Optional.ofNullable(rc.getRecruitTimes())
@@ -162,9 +155,9 @@ public class MatchService {
     private List<MatchResponseDto.WorkRequest> toWorkRequestList(List<Match> allByJobConditionWithStatus) {
         return allByJobConditionWithStatus.stream()
                 .map(match -> {
-                    Elder elder = match.getRequirementCondition().getElder();
+                    Elder elder = match.getRecruitCondition().getElder();;
                     Center center = elder.getCenter();
-                    RecruitCondition rc = match.getRequirementCondition();
+                    RecruitCondition rc = match.getRecruitCondition();
                     return MatchResponseDto.WorkRequest.builder()
                             .matchId(match.getId())
                             .elderId(elder.getElderId())
@@ -183,108 +176,7 @@ public class MatchService {
                 .collect(Collectors.toList());
     }
 
-    public List<MatchedCaregiver> getRecommendList(Long request) {
 
-        List<JobCondition> recommendedList  = jobConditionRepository.findAllRecommendedListByElder(request);
-        RecruitCondition recruitCondition = recruitCondRepository.findById(request)
-                .orElseThrow(()-> new GlobalException(ErrorCode.RECRUIT_NOT_FOUND));
-
-        // 매칭 점수 계산
-        List<MatchedCaregiver> result = new ArrayList<>();
-        for (JobCondition jobCondition : recommendedList) {
-            int timeScore = calculateTimeScore(jobCondition,recruitCondition);
-            int conditionScore = calculateConditionScore(jobCondition,recruitCondition);
-
-            Caregiver caregiver = jobCondition.getCaregiver();
-            MatchStatus st = matchRepository.findAllByJobConditionAndRecruitCondition(recruitCondition.getRecruitConditionId(),
-                    jobCondition.getId());
-
-
-            // 최종 점수 계산 (persent)
-            int persent = (timeScore + conditionScore) / 2;
-
-            // 결과 리스트 추가
-            result.add(MatchedCaregiver.builder()
-                            .jobConditionId(jobCondition.getId())
-                            .caregiverName(caregiver.getName())
-                            .imgUrl(caregiver.getImg())
-                            .matchStatus(st == null ? MatchStatus.NONE : st )
-                            .score(persent)
-                    .build());
-        }
-
-        // 점수가 높은 순으로 정렬
-        result.sort((a, b) -> Integer.compare(b.getScore(), a.getScore()));
-
-        return result;
-    }
-
-    private int calculateConditionScore(JobCondition jc,RecruitCondition rc) {
-        int totalScore = 100; // 기본 점수
-
-        // 체크할 필드 목록 (getter 메서드 이름을 기반으로 자동 체크)
-        List<String> conditionFields = List.of(
-                "SelfFeeding", "MealPreparation", "CookingAssistance", "EnteralNutritionSupport",
-                "SelfToileting", "OccasionalToiletingAssist", "DiaperCare", "CatheterOrStomaCare",
-                "IndependentMobility", "MobilityAssist", "WheelchairAssist", "Immobile",
-                "CleaningLaundryAssist", "BathingAssist", "HospitalAccompaniment",
-                "ExerciseSupport", "EmotionalSupport", "CognitiveStimulation"
-        );
-
-        try {
-            for (String field : conditionFields) {
-                Method jcMethod = JobCondition.class.getMethod("get" + field);
-                Method rcMethod = RecruitCondition.class.getMethod("is" + field);
-
-                ScheduleAvailability jcValue = (ScheduleAvailability) jcMethod.invoke(jc);
-                boolean rcValue = (boolean) rcMethod.invoke(rc);
-
-                if (jcValue == ScheduleAvailability.IMPOSSIBLE && rcValue) {
-                    totalScore -= 20;
-                } else if (jcValue == ScheduleAvailability.NEGOTIABLE) {
-                    totalScore -= 2;
-                }
-            }
-        } catch (Exception e) {
-            throw new GlobalException(ErrorCode.ERROR_AT_CALCULATE_LOGIC);
-        }
-        return Math.max(0, totalScore);
-    }
-
-    private int calculateTimeScore(JobCondition jc, RecruitCondition rc) {
-        List<RecruitTime> recruitTimes = rc.getRecruitTimes();
-        int totalScore = 0;
-        int matchedDays = 0;
-
-        // JobCondition의 근무 시간을 비트마스크로 변환
-        int jobTimeMask = getTimeMask(jc.getStartTime(), jc.getEndTime());
-        int jobDayMask = jc.getDayOfWeek();
-
-        for (RecruitTime rt : recruitTimes) {
-            int recruitDayBit = getDayOfWeekBit(rt.getDayOfWeek());
-
-
-            if ((jobDayMask & recruitDayBit) == 0) {
-                continue;
-            }
-
-            matchedDays++;
-
-            int recruitTimeMask = getTimeMask(rt.getStartTime(), rt.getEndTime());
-
-            // 겹치는 시간 계산 (비트 연산)
-            int overlappedTimeMask = jobTimeMask & recruitTimeMask;
-            int overlapDuration = Integer.bitCount(overlappedTimeMask);
-            int jobDuration = Integer.bitCount(recruitTimeMask);
-
-            // 비율 기반 점수 계산
-            int score = (int) ((overlapDuration / (double) jobDuration) * 100);
-
-            totalScore += score;
-        }
-
-        return (matchedDays > 0) ? (totalScore / matchedDays) : 0;
-    }
 
     private int getTimeMask(long startTime, long endTime) {
         int mask = 0;
@@ -314,7 +206,7 @@ public class MatchService {
                 .orElseThrow(() -> new GlobalException(ErrorCode.RECRUIT_NOT_FOUND));
         Match match = Match.builder()
                 .jobCondition(jc)
-                .requirementCondition(rc)
+                .recruitCondition(rc)
                 .status(MatchStatus.WAITING)
                         .build();
         matchRepository.save(match);
@@ -364,4 +256,74 @@ public class MatchService {
 
         return matchRepository.findByCenterId(centerId);
     }
+
+    //    public List<MatchedCaregiver> getRecommendList(Long rcId) {
+//
+//        List<JobCondition> recommendedList  = jobConditionRepository.findAllRecommendedListByElder(rcId);
+//        RecruitCondition recruitCondition = recruitCondRepository.findById(rcId)
+//                .orElseThrow(()-> new GlobalException(ErrorCode.RECRUIT_NOT_FOUND));
+//
+//        // 매칭 점수 계산
+//        List<MatchedCaregiver> result = new ArrayList<>();
+//        for (JobCondition jobCondition : recommendedList) {
+//            int timeScore = calculateTimeScore(jobCondition,recruitCondition);
+//            int conditionScore = calculateConditionScore(jobCondition,recruitCondition);
+//
+//            Caregiver caregiver = jobCondition.getCaregiver();
+//            MatchStatus st = matchRepository.findByJobConditionAndRecruitCondition(recruitCondition.getRecruitConditionId(),
+//                    jobCondition.getId());
+//
+//
+//            // 최종 점수 계산 (persent)
+//            int persent = (timeScore + conditionScore) / 2;
+//
+//            // 결과 리스트 추가
+//            result.add(MatchedCaregiver.builder()
+//                            .jobConditionId(jobCondition.getId())
+//                            .caregiverName(caregiver.getName())
+//                            .imgUrl(caregiver.getImg())
+//                            .matchStatus(st == null ? MatchStatus.NONE : st )
+//                            .score(persent)
+//                    .build());
+//        }
+//
+//        // 점수가 높은 순으로 정렬
+//        result.sort((a, b) -> Integer.compare(b.getScore(), a.getScore()));
+//
+//        return result;
+//    }
+//    private int calculateTimeScore(JobCondition jc, RecruitCondition rc) {
+//        List<RecruitTime> recruitTimes = rc.getRecruitTimes();
+//        int totalScore = 0;
+//        int matchedDays = 0;
+//
+//        // JobCondition의 근무 시간을 비트마스크로 변환
+//        int jobTimeMask = getTimeMask(jc.getStartTime(), jc.getEndTime());
+//        int jobDayMask = jc.getDayOfWeek();
+//
+//        for (RecruitTime rt : recruitTimes) {
+//            int recruitDayBit = getDayOfWeekBit(rt.getDayOfWeek());
+//
+//
+//            if ((jobDayMask & recruitDayBit) == 0) {
+//                continue;
+//            }
+//
+//            matchedDays++;
+//
+//            int recruitTimeMask = getTimeMask(rt.getStartTime(), rt.getEndTime());
+//
+//            // 겹치는 시간 계산 (비트 연산)
+//            int overlappedTimeMask = jobTimeMask & recruitTimeMask;
+//            int overlapDuration = Integer.bitCount(overlappedTimeMask);
+//            int jobDuration = Integer.bitCount(recruitTimeMask);
+//
+//            // 비율 기반 점수 계산
+//            int score = (int) ((overlapDuration / (double) jobDuration) * 100);
+//
+//            totalScore += score;
+//        }
+//
+//        return (matchedDays > 0) ? (totalScore / matchedDays) : 0;
+//    }
 }

--- a/src/main/java/com/example/springserver/domain/score/controller/ScoreController.java
+++ b/src/main/java/com/example/springserver/domain/score/controller/ScoreController.java
@@ -1,0 +1,36 @@
+package com.example.springserver.domain.score.controller;
+
+import com.example.springserver.domain.match.converter.MatchConverter;
+import com.example.springserver.domain.match.dto.request.MatchRequestDto.RecruitReq;
+import com.example.springserver.domain.match.dto.response.MatchResponseDto.*;
+import com.example.springserver.domain.match.entity.Match;
+import com.example.springserver.domain.match.service.MatchService;
+import com.example.springserver.domain.score.dto.ScoreDto;
+import com.example.springserver.domain.score.service.ScoreService;
+import com.example.springserver.global.security.util.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@Validated
+@Tag(name = "Score API", description = "추천 요양보호사 점수 조회 API ")
+@RequestMapping("/score")
+@RequiredArgsConstructor
+public class ScoreController {
+
+    private final ScoreService scoreService;
+
+    @Operation(summary = "어르신별 추천된 요양보호사리스트 조회", description = "Get")
+    @GetMapping("/recommends/{recruit_condition_id}")
+    public ScoreDto.RecommendCaregiverListDto getRecommendListByElder(@AuthenticationPrincipal CustomUserDetails user,
+                                                                      @PathVariable("recruit_condition_id") Long request) {
+        return scoreService.getRecommendList(request);
+    }
+}

--- a/src/main/java/com/example/springserver/domain/score/converter/ScoreConverter.java
+++ b/src/main/java/com/example/springserver/domain/score/converter/ScoreConverter.java
@@ -1,0 +1,27 @@
+package com.example.springserver.domain.score.converter;
+
+import com.example.springserver.domain.score.dto.ScoreDto.*;
+import com.example.springserver.domain.score.entity.MatchScore;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class ScoreConverter {
+
+    public static RecommendCaregiverListDto toRecommendCaregiverListDto(List<MatchScore> scores){
+        return (RecommendCaregiverListDto) scores.stream()
+                .map(ScoreConverter::toRecommendCaregiverDto)
+                .toList();
+    }
+
+    public static RecommendCaregiverDto toRecommendCaregiverDto(MatchScore score){
+        return RecommendCaregiverDto.builder()
+                .jobConditonId(score.getJobCondition().getId())
+                .score(score.getScore())
+                .imgUrl(score.getCaregiverImg())
+                .caregiverName(score.getCaregiverName())
+                .matchStatus(score.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/example/springserver/domain/score/dto/ScoreDto.java
+++ b/src/main/java/com/example/springserver/domain/score/dto/ScoreDto.java
@@ -1,0 +1,33 @@
+package com.example.springserver.domain.score.dto;
+
+import com.example.springserver.domain.match.entity.enums.MatchStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+public class ScoreDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RecommendCaregiverListDto{
+        List<RecommendCaregiverDto> recommendCaregivers;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RecommendCaregiverDto {
+        Long jobConditonId;
+        Integer score;
+        String imgUrl;
+        String caregiverName;
+        MatchStatus matchStatus;
+    }
+}

--- a/src/main/java/com/example/springserver/domain/score/entity/MatchScore.java
+++ b/src/main/java/com/example/springserver/domain/score/entity/MatchScore.java
@@ -1,7 +1,6 @@
-package com.example.springserver.domain.match.entity;
+package com.example.springserver.domain.score.entity;
 
 import com.example.springserver.domain.caregiver.entity.JobCondition;
-import com.example.springserver.domain.center.entity.Center;
 import com.example.springserver.domain.center.entity.RecruitCondition;
 import com.example.springserver.domain.match.entity.enums.MatchStatus;
 import com.example.springserver.global.common.entity.BaseEntity;
@@ -9,26 +8,30 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.hibernate.annotations.Where;
+import org.springframework.data.jpa.repository.Lock;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Setter
 @Entity
-@Table(name = "`match`")
 @Where(clause = "deleted_at IS NULL")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Match extends BaseEntity {
+@Table(
+        name = "match_score",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_job_recruit",
+                columnNames = {"job_condition", "recruit_condition"}
+        )
+)
+public class MatchScore extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "match_id", nullable = false)
+    @Column(name = "match_score_id", nullable = false)
     private Long id;
-
-    @Column(name = "status")
-    @Enumerated(EnumType.STRING)
-    private MatchStatus status;
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -40,12 +43,24 @@ public class Match extends BaseEntity {
     @JoinColumn(name = "job_condition_id", nullable = false)
     private JobCondition jobCondition;
 
+    @NotNull
+    @Column(name = "score")
+    private Integer score;
+
+    @NotNull
+    @Column(name = "caregiver_name",length = 40)
+    private String caregiverName;
+
+    @Column(name = "caregiver_img")
+    private String caregiverImg;
+
+    @Column(name = "matching_status")
+    @Enumerated(EnumType.STRING)
+    private MatchStatus status;
+
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     @Version
     private Integer version;
-    public Center getCenter() {
-        return this.recruitCondition.getElder().getCenter();
-    }
 }

--- a/src/main/java/com/example/springserver/domain/score/repository/ScoreRepository.java
+++ b/src/main/java/com/example/springserver/domain/score/repository/ScoreRepository.java
@@ -8,37 +8,87 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
 public interface ScoreRepository extends JpaRepository<MatchScore,Long> {
 
-
+    /**
+     * RC_ID 기준으로 List<MatchScore> 조회합니다.
+     */
     @Query(value = "SELECT * FROM match_score WHERE recruit_condition_id = :recruit_condition_id ORDER BY score FOR UPDATE;",nativeQuery = true)
     Optional<List<MatchScore>> findByRecruitConditionId(@Param("recruit_condition_id") Long request);
 
+    /**
+     * JC_ID와 RC_ID 기준으로 List<MatchScore> 조회합니다.
+     */
     @Query(value = "SELECT jc.* FROM job_condition jc\n" +
     "JOIN match_score ms ON jc.job_condition_id = ms.job_condition_id\n" +
     "WHERE ms.recruit_condition_id = :recruitConditionId\n"
     , nativeQuery = true)
     Optional<List<JobCondition>> findAllByRecruitConditionId(@Param("recruitConditionId") Long recruitId);
 
+    /**
+     *  RC 기준으로 조회한 모든 match_score에 대해 soft_delete 해버립니다.
+     */
     @Modifying
+    @Transactional
     @Query(value = "UPDATE match_score\n" +
             "SET deleted_at = NOW()\n" +
             "WHERE recruit_condition_id = :recruitConditionId;",nativeQuery = true)
     void deleteAllByRecruitConditionId(@Param("recruitConditionId") Long recruitConditionId);
 
+    /**
+     *  JC 기준으로 조회한 모든 match_score에 대해 soft_delete 해버립니다.
+     */
     @Modifying
+    @Transactional
     @Query(value = "UPDATE match_score\n" +
             "SET deleted_at = NOW()\n" +
             "WHERE job_condition_id = :jobConditionId;",nativeQuery = true)
     void deleteAllByJobConditionId(@Param("jobConditionId") Long jobConditionId);
 
 
+    /**
+     * 스케줄러에서 호출되는 Hard_Delete 입니다.
+     */
     @Modifying
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Transactional
     @Query("DELETE FROM MatchScore m WHERE m.deletedAt IS NOT NULL")
     void deleteAllMarkedAsDeleted();
+
+    /**
+     * Deleted_at 이 Null이 아니어도 부를수 있는 커스텀 SQL 쿼리입니다.
+     * 이 쿼리를 통해서 기존 MatchScore 존재하는지 불러올거예요.
+     */
+    @Query(value = "SELECT * FROM match_score WHERE job_condition_id = :jobConditionId", nativeQuery = true)
+    List<MatchScore> findAllByJobConditionIncludingDeleted(@Param("jobConditionId") Long jobConditionId);
+
+    @Query(value = "SELECT * FROM match_score WHERE recruit_condition_id = :recruitConditionId", nativeQuery = true)
+    List<MatchScore> findAllByRecruitConditionIncludingDeleted(Long recruitConditionId);
+
+    /**
+     *  UPSERT 인데 당장에 쓰이지 않습니다 무시 ㄱㄱ
+     */
+//    @Modifying
+//    @Query(value = """
+//    INSERT INTO match_score (
+//        caregiver_name, caregiver_img, recruit_condition_id, job_condition_id, score, matching_status, created_at, updated_at
+//    ) VALUES (
+//        :caregiverName, :caregiverImg, :rcId, :jcId, :score, :status, NOW(), NOW()
+//    ) ON DUPLICATE KEY UPDATE
+//        deleted_at = NULL,
+//        score = VALUES(score),
+//        matching_status = VALUES(matching_status),
+//        updated_at = NOW()
+//    """, nativeQuery = true)
+//    void upsertScore(@Param("caregiverName") String caregiverName,
+//                     @Param("caregiverImg") String caregiverImg,
+//                     @Param("rcId") Long recruitConditionId,
+//                     @Param("jcId") Long jobConditionId,
+//                     @Param("score") int score,
+//                     @Param("status") String status);
+
 }

--- a/src/main/java/com/example/springserver/domain/score/repository/ScoreRepository.java
+++ b/src/main/java/com/example/springserver/domain/score/repository/ScoreRepository.java
@@ -1,0 +1,44 @@
+package com.example.springserver.domain.score.repository;
+
+import com.example.springserver.domain.caregiver.entity.JobCondition;
+import com.example.springserver.domain.score.entity.MatchScore;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ScoreRepository extends JpaRepository<MatchScore,Long> {
+
+
+    @Query(value = "SELECT * FROM match_score WHERE recruit_condition_id = :recruit_condition_id ORDER BY score FOR UPDATE;",nativeQuery = true)
+    Optional<List<MatchScore>> findByRecruitConditionId(@Param("recruit_condition_id") Long request);
+
+    @Query(value = "SELECT jc.* FROM job_condition jc\n" +
+    "JOIN match_score ms ON jc.job_condition_id = ms.job_condition_id\n" +
+    "WHERE ms.recruit_condition_id = :recruitConditionId\n"
+    , nativeQuery = true)
+    Optional<List<JobCondition>> findAllByRecruitConditionId(@Param("recruitConditionId") Long recruitId);
+
+    @Modifying
+    @Query(value = "UPDATE match_score\n" +
+            "SET deleted_at = NOW()\n" +
+            "WHERE recruit_condition_id = :recruitConditionId;",nativeQuery = true)
+    void deleteAllByRecruitConditionId(@Param("recruitConditionId") Long recruitConditionId);
+
+    @Modifying
+    @Query(value = "UPDATE match_score\n" +
+            "SET deleted_at = NOW()\n" +
+            "WHERE job_condition_id = :jobConditionId;",nativeQuery = true)
+    void deleteAllByJobConditionId(@Param("jobConditionId") Long jobConditionId);
+
+
+    @Modifying
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("DELETE FROM MatchScore m WHERE m.deletedAt IS NOT NULL")
+    void deleteAllMarkedAsDeleted();
+}

--- a/src/main/java/com/example/springserver/domain/score/service/ScoreService.java
+++ b/src/main/java/com/example/springserver/domain/score/service/ScoreService.java
@@ -1,0 +1,30 @@
+package com.example.springserver.domain.score.service;
+
+import com.example.springserver.domain.score.converter.ScoreConverter;
+import com.example.springserver.domain.score.dto.ScoreDto;
+import com.example.springserver.domain.score.entity.MatchScore;
+import com.example.springserver.domain.score.repository.ScoreRepository;
+import com.example.springserver.global.apiPayload.format.ErrorCode;
+import com.example.springserver.global.apiPayload.format.GlobalException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ScoreService {
+
+    private final ScoreRepository scoreRepository;
+
+    public ScoreDto.RecommendCaregiverListDto getRecommendList(Long request) {
+        List<MatchScore> byRecruitConditionId = scoreRepository.findByRecruitConditionId(request)
+                .orElseThrow(()-> new GlobalException(ErrorCode.RECOMMEND_LIST_NOT_FOUND));
+        return ScoreConverter.toRecommendCaregiverListDto(byRecruitConditionId);
+    }
+}

--- a/src/main/java/com/example/springserver/global/apiPayload/format/ErrorCode.java
+++ b/src/main/java/com/example/springserver/global/apiPayload/format/ErrorCode.java
@@ -83,7 +83,11 @@ public enum ErrorCode {
     NOT_ALLOW_STRING(HttpStatus.INTERNAL_SERVER_ERROR,"NO STRING" ,"백엔드 담당자가 String으로 반환을 설정했습니다. String 반환은 허용되지 않습니다. 담당자에게 문의하세요!"),
 
     // 매칭 에러
-    ERROR_AT_CALCULATE_LOGIC(HttpStatus.NOT_FOUND,"MATCH001", "점수계산중 오류발생" ), MONEY_NOT_MATCHED(HttpStatus.BAD_REQUEST,"MATCH002" ,"시급이 일치하지 않습니다.");
+    ERROR_AT_CALCULATE_LOGIC(HttpStatus.NOT_FOUND,"MATCH001", "점수계산중 오류발생" )
+    , MONEY_NOT_MATCHED(HttpStatus.BAD_REQUEST,"MATCH002" ,"시급이 일치하지 않습니다."),
+    //추천리스트 조회
+    RECOMMEND_LIST_NOT_FOUND(HttpStatus.NOT_FOUND,"SCORE001","추천리스트가 존재하지 않습니다."),
+    MATCH_SCORE_NOT_FOUND(HttpStatus.NOT_FOUND,"SCORE002" ,"점수리스트가 존재하지 않습니다." );
 
 
     private final HttpStatus status;

--- a/src/main/java/com/example/springserver/global/apiPayload/format/ErrorCode.java
+++ b/src/main/java/com/example/springserver/global/apiPayload/format/ErrorCode.java
@@ -65,6 +65,7 @@ public enum ErrorCode {
     // 지역 관련 에러
     BAD_REQUEST(HttpStatus.BAD_REQUEST,"LOCATION4001","찾고자 하는 지역 입력이 없습니다."),
     LOCATION_NOT_FOUND(HttpStatus.BAD_REQUEST,"LOCATION4001","지역이 존재하지 않습니다."),
+    WORK_LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND,"WORK_LOCATION001" ,"근무가능지역이 존재하지 않습니다."),
 
     // 매치 관련 에러
     MATCH_NOT_FOUND(HttpStatus.BAD_REQUEST,"MATCH4001","매칭을 찾을 수 없습니다."),

--- a/src/main/java/com/example/springserver/service/event/JobConditionChangedEvent.java
+++ b/src/main/java/com/example/springserver/service/event/JobConditionChangedEvent.java
@@ -1,0 +1,14 @@
+package com.example.springserver.service.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class JobConditionChangedEvent extends ApplicationEvent {
+    private final Long jobConditionId;
+
+    public JobConditionChangedEvent(Object source, Long jobConditionId) {
+        super(source);
+        this.jobConditionId = jobConditionId;
+    }
+}

--- a/src/main/java/com/example/springserver/service/event/RecruitConditionChangedEvent.java
+++ b/src/main/java/com/example/springserver/service/event/RecruitConditionChangedEvent.java
@@ -1,0 +1,14 @@
+package com.example.springserver.service.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class RecruitConditionChangedEvent extends ApplicationEvent {
+    private final Long recruitConditionId;
+
+    public RecruitConditionChangedEvent(Object source, Long recruitConditionId) {
+        super(source);
+        this.recruitConditionId = recruitConditionId;
+    }
+}

--- a/src/main/java/com/example/springserver/service/score/scheduler/ScoreCalculateScheduler.java
+++ b/src/main/java/com/example/springserver/service/score/scheduler/ScoreCalculateScheduler.java
@@ -1,0 +1,25 @@
+package com.example.springserver.service.score.scheduler;
+
+import com.example.springserver.service.score.service.ScoreCalculationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ScoreCalculateScheduler {
+
+    private final ScoreCalculationService scoreCalculationService;
+
+    @Scheduled(cron = "0 0 4 * * ?")
+    public void calculateDailyScores() {
+        System.out.println("[스케줄러 실행] 매일 새벽 4시, 전체 점수 업데이트 시작...");
+
+        scoreCalculationService.summarize();
+
+        System.out.println("[스케줄러 실행] 전체 점수 업데이트 완료!");
+    }
+
+
+
+}

--- a/src/main/java/com/example/springserver/service/score/scheduler/ScoreCalculateScheduler.java
+++ b/src/main/java/com/example/springserver/service/score/scheduler/ScoreCalculateScheduler.java
@@ -11,6 +11,9 @@ public class ScoreCalculateScheduler {
 
     private final ScoreCalculationService scoreCalculationService;
 
+    /**
+     * 매일 매월 새벽 4시 실행되는 스케줄러 입니다.
+     */
     @Scheduled(cron = "0 0 4 * * ?")
     public void calculateDailyScores() {
         System.out.println("[스케줄러 실행] 매일 새벽 4시, 전체 점수 업데이트 시작...");
@@ -19,7 +22,4 @@ public class ScoreCalculateScheduler {
 
         System.out.println("[스케줄러 실행] 전체 점수 업데이트 완료!");
     }
-
-
-
 }

--- a/src/main/java/com/example/springserver/service/score/scheduler/ScoreRecalculateEventListener.java
+++ b/src/main/java/com/example/springserver/service/score/scheduler/ScoreRecalculateEventListener.java
@@ -1,0 +1,34 @@
+package com.example.springserver.service.score.scheduler;
+
+import com.example.springserver.service.event.JobConditionChangedEvent;
+import com.example.springserver.service.event.RecruitConditionChangedEvent;
+import com.example.springserver.service.score.service.ScoreCalculationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ScoreRecalculateEventListener {
+
+    private final ScoreCalculationService scoreCalculationService;
+
+    @Async
+    @EventListener
+    public void handleRecruitConditionChanged(RecruitConditionChangedEvent event) {
+        System.out.println("[이벤트 감지] RecruitCondition 변경됨. 점수 업데이트 실행.");
+
+        // 변경된 RecruitCondition ID를 기준으로 점수 업데이트
+        scoreCalculationService.recalculateScoresForRecruit(event.getRecruitConditionId());
+    }
+
+    @Async
+    @EventListener
+    public void handleJobConditionChanged(JobConditionChangedEvent event) {
+        System.out.println("[이벤트 감지] JobCondition 변경됨. 점수 업데이트 실행.");
+
+        // 변경된 RecruitCondition ID를 기준으로 점수 업데이트
+        scoreCalculationService.recalculateScoresForJob(event.getJobConditionId());
+    }
+}

--- a/src/main/java/com/example/springserver/service/score/scheduler/ScoreRecalculateEventListener.java
+++ b/src/main/java/com/example/springserver/service/score/scheduler/ScoreRecalculateEventListener.java
@@ -4,31 +4,42 @@ import com.example.springserver.service.event.JobConditionChangedEvent;
 import com.example.springserver.service.event.RecruitConditionChangedEvent;
 import com.example.springserver.service.score.service.ScoreCalculationService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
 public class ScoreRecalculateEventListener {
 
-    private final ScoreCalculationService scoreCalculationService;
+    private final ApplicationContext applicationContext;
 
-    @Async
-    @EventListener
+    /**
+     * RC 변경된 Event 감지
+     * recalculateScoresForRecruitWithNewTransaction 메서드를 통해서
+     * 변경에 따른 점수계산으로 들어갑니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleRecruitConditionChanged(RecruitConditionChangedEvent event) {
         System.out.println("[이벤트 감지] RecruitCondition 변경됨. 점수 업데이트 실행.");
 
-        // 변경된 RecruitCondition ID를 기준으로 점수 업데이트
-        scoreCalculationService.recalculateScoresForRecruit(event.getRecruitConditionId());
+        // 추가 및 변경된 RecruitCondition ID를 기준으로 점수 업데이트
+        applicationContext.getBean(ScoreCalculationService.class)
+                .recalculateScoresForRecruitWithNewTransaction(event.getRecruitConditionId());
     }
 
-    @Async
-    @EventListener
+
+
+    /**
+     * JC 변경된 Event 감지
+     * recalculateScoresForJobWithNewTransaction 메서드를 통해서
+     * 변경에 따른 점수계산으로 들어갑니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleJobConditionChanged(JobConditionChangedEvent event) {
         System.out.println("[이벤트 감지] JobCondition 변경됨. 점수 업데이트 실행.");
-
-        // 변경된 RecruitCondition ID를 기준으로 점수 업데이트
-        scoreCalculationService.recalculateScoresForJob(event.getJobConditionId());
+        applicationContext.getBean(ScoreCalculationService.class)
+                .recalculateScoresForJobWithNewTransaction(event.getJobConditionId());
     }
 }

--- a/src/main/java/com/example/springserver/service/score/service/ScoreCalculationService.java
+++ b/src/main/java/com/example/springserver/service/score/service/ScoreCalculationService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -47,83 +48,25 @@ public class ScoreCalculationService {
      *  기존 MatchScore가 존재하면 복구 및 업데이트,
      *  존재하지 않으면 새로 생성합니다.
      */
+    //rc 변경시 update
     @Transactional
     public void recalculateScoresForRecruit(Long recruitConditionId) {
-        // RC 조회 + RecruitTime → 시간 마스킹
-        RecruitCondition rc = recruitCondRepository.findById(recruitConditionId)
-                .orElseThrow(() -> new GlobalException(ErrorCode.RECRUIT_NOT_FOUND));
+        RecruitCondition rc = fetchRecruitCondition(recruitConditionId);
+        Map<Week, Long> rcDayTimeMap = buildRcDayTimeMap(rc);
+        int rcDayMask = calculateRcDayMask(rcDayTimeMap);
 
-        Map<Week, Long> rcDayTimeMap = rc.getRecruitTimes().stream()
-                .collect(Collectors.toMap(
-                        RecruitTime::getDayOfWeek,
-                        rt -> getTimeMask(rt.getStartTime(), rt.getEndTime()),
-                        (a, b) -> a | b
-                ));
+        List<JobCondition> candidates = fetchJobConditionCandidatesByLocation(rc);
+        Map<String, MatchScore> existingScoreMap = fetchExistingMatchScoresMapForRecruit(rc.getRecruitConditionId());
+        Map<Long, Match> matchMap = fetchMatchStatusMapForRecruit(rc.getRecruitConditionId());
 
-        int rcDayMask = rcDayTimeMap.keySet().stream()
-                .mapToInt(Week::getBitMask)
-                .reduce(0, (a, b) -> a | b);
+        List<MatchScore> results = calculateMatchScoresForRecruit(candidates, rc, rcDayTimeMap, rcDayMask, existingScoreMap, matchMap);
+        List<MatchScore> toSoftDelete = filterSoftDeleteTargetsForRecruit(existingScoreMap, results);
 
-        // JC 후보 조회 (지역 기준 필터링)
-        List<JobCondition> candidates = jobConditionRepository.findAllByRecommendedListByElder(
-                rc.getRecruitLocation().getLocationId()
-        ).orElseThrow(() -> new GlobalException(ErrorCode.RECOMMEND_LIST_NOT_FOUND));
-
-        // 기존 MatchScore 모두 불러오기 (soft-delete 포함)
-        List<MatchScore> existingScores = scoreRepository.findAllByRecruitConditionIncludingDeleted(recruitConditionId);
-        Map<String, MatchScore> scoreMap = existingScores.stream()
-                .collect(Collectors.toMap(
-                        ms -> ms.getJobCondition().getId() + "_" + ms.getRecruitCondition().getRecruitConditionId(),
-                        ms -> ms
-                ));
-
-        // Match 상태 조회
-        List<Match> matches = matchRepository.findAllByRecruitCondition_RecruitConditionId(rc.getRecruitConditionId());
-        Map<Long, Match> matchMap = matches.stream()
-                .collect(Collectors.toMap(
-                        m -> m.getJobCondition().getId(),
-                        m -> m
-                ));
-
-        List<MatchScore> results = new ArrayList<>();
-
-        for (JobCondition jc : candidates) {
-            if ((jc.getDayOfWeek() & rcDayMask) == 0) continue;
-
-            int conditionScore = calculateConditionScore(jc, rc);
-            int timeScore = calculateTimeScore(rcDayTimeMap, jc);
-            int finalScore = (conditionScore + timeScore) / 2;
-
-            String key = jc.getId() + "_" + rc.getRecruitConditionId();
-
-            if (scoreMap.containsKey(key)) {
-                MatchScore existing = scoreMap.get(key);
-                existing.setScore(finalScore);
-                existing.setStatus(Optional.ofNullable(matchMap.get(jc.getId()))
-                        .map(Match::getStatus)
-                        .orElse(MatchStatus.NONE));
-                existing.setDeletedAt(null);
-                results.add(existing);
-            } else {
-                MatchScore newScore = MatchScore.builder()
-                        .caregiverName(jc.getCaregiver().getName())
-                        .caregiverImg(jc.getCaregiver().getImg())
-                        .recruitCondition(rc)
-                        .jobCondition(jc)
-                        .score(finalScore)
-                        .status(Optional.ofNullable(matchMap.get(jc.getId()))
-                                .map(Match::getStatus)
-                                .orElse(MatchStatus.NONE))
-                        .build();
-                results.add(newScore);
-            }
-        }
-
+        results.addAll(toSoftDelete);
         scoreRepository.saveAll(results);
     }
 
     // JC 변경시 Update
-
     /**
      * JC 변경 시 점수 재계산을 수행합니다.
      * 존재하는 MatchScore는 수정/복구하고, 존재하지 않으면 새로 생성하여 저장합니다.
@@ -158,8 +101,154 @@ public class ScoreCalculationService {
                 results.add(created);
             }
         }
+        Set<String> processedKeys = results.stream()
+                .map(ms -> generateKey(ms.getJobCondition().getId(), ms.getRecruitCondition().getRecruitConditionId()))
+                .collect(Collectors.toSet());
 
+        List<MatchScore> toSoftDelete = existingScoreMap.entrySet().stream()
+                .filter(entry -> !processedKeys.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .filter(ms -> ms.getDeletedAt() == null) // 이미 삭제된 건 제외
+                .peek(ms -> ms.setDeletedAt(LocalDateTime.now()))
+                .toList();
+
+        results.addAll(toSoftDelete);
         scoreRepository.saveAll(results);
+    }
+    /**
+     * 주어진 ID로 RecruitCondition을 조회합니다.
+     * 존재하지 않으면 예외를 발생시킵니다.
+     */
+    private RecruitCondition fetchRecruitCondition(Long recruitConditionId) {
+        return recruitCondRepository.findById(recruitConditionId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.RECRUIT_NOT_FOUND));
+    }
+
+    /**
+     * RecruitCondition에 등록된 RecruitTime들을 기반으로
+     * 요일별 시간 마스크(Map<Week, Long>)를 생성합니다.
+     */
+    private Map<Week, Long> buildRcDayTimeMap(RecruitCondition rc) {
+        return rc.getRecruitTimes().stream()
+                .collect(Collectors.toMap(
+                        RecruitTime::getDayOfWeek,
+                        rt -> getTimeMask(rt.getStartTime(), rt.getEndTime()),
+                        (a, b) -> a | b
+                ));
+    }
+
+    /**
+     * RC가 가능한 요일 목록을 비트 OR 연산을 통해 하나의 int 마스크로 반환합니다.
+     * (ex: 월/수/금 → 0b0010101)
+     */
+    private int calculateRcDayMask(Map<Week, Long> rcDayTimeMap) {
+        return rcDayTimeMap.keySet().stream()
+                .mapToInt(Week::getBitMask)
+                .reduce(0, (a, b) -> a | b);
+    }
+
+    /**
+     * RecruitCondition의 근무 지역을 기준으로 추천 가능한 JobCondition 리스트를 조회합니다.
+     * 존재하지 않으면 예외를 발생시킵니다.
+     */
+    private List<JobCondition> fetchJobConditionCandidatesByLocation(RecruitCondition rc) {
+        return jobConditionRepository.findAllByRecommendedListByElder(
+                rc.getRecruitLocation().getLocationId()
+        ).orElseThrow(() -> new GlobalException(ErrorCode.RECOMMEND_LIST_NOT_FOUND));
+    }
+
+    /**
+     * RecruitCondition 기준으로 기존 MatchScore 리스트를 조회합니다.
+     * soft-delete 포함하며, (jobId_rcId) 형태의 Key로 Map을 구성해 반환합니다.
+     */
+    private Map<String, MatchScore> fetchExistingMatchScoresMapForRecruit(Long recruitConditionId) {
+        List<MatchScore> existing = scoreRepository.findAllByRecruitConditionIncludingDeleted(recruitConditionId);
+        return existing.stream().collect(Collectors.toMap(
+                ms -> generateKey(ms.getJobCondition().getId(), ms.getRecruitCondition().getRecruitConditionId()),
+                ms -> ms
+        ));
+    }
+
+    /**
+     * RecruitCondition 기준으로 기존 Match 리스트를 조회하고
+     * JobCondition ID를 키로 하는 Map 형태로 반환합니다.
+     */
+    private Map<Long, Match> fetchMatchStatusMapForRecruit(Long recruitConditionId) {
+        List<Match> matches = matchRepository.findAllByRecruitCondition_RecruitConditionId(recruitConditionId);
+        return matches.stream().collect(Collectors.toMap(
+                m -> m.getJobCondition().getId(),
+                m -> m
+        ));
+    }
+
+    /**
+     * 주어진 JobCondition 후보 리스트와 RecruitCondition에 대해
+     * 유효한 점수를 계산하여 MatchScore 리스트로 반환합니다.
+     * 이미 존재하는 MatchScore는 복구/갱신, 없으면 새로 생성합니다.
+     */
+    private List<MatchScore> calculateMatchScoresForRecruit(
+            List<JobCondition> candidates,
+            RecruitCondition rc,
+            Map<Week, Long> rcDayTimeMap,
+            int rcDayMask,
+            Map<String, MatchScore> existingScoreMap,
+            Map<Long, Match> matchMap
+    ) {
+        List<MatchScore> results = new ArrayList<>();
+
+        for (JobCondition jc : candidates) {
+            if ((jc.getDayOfWeek() & rcDayMask) == 0) continue;
+
+            int conditionScore = calculateConditionScore(jc, rc);
+            int timeScore = calculateTimeScore(rcDayTimeMap, jc);
+            int finalScore = (conditionScore + timeScore) / 2;
+
+            String key = jc.getId() + "_" + rc.getRecruitConditionId();
+
+            if (existingScoreMap.containsKey(key)) {
+                MatchScore existing = existingScoreMap.get(key);
+                existing.setScore(finalScore);
+                existing.setStatus(Optional.ofNullable(matchMap.get(jc.getId()))
+                        .map(Match::getStatus)
+                        .orElse(MatchStatus.NONE));
+                existing.setDeletedAt(null);
+                results.add(existing);
+            } else {
+                MatchScore newScore = MatchScore.builder()
+                        .caregiverName(jc.getCaregiver().getName())
+                        .caregiverImg(jc.getCaregiver().getImg())
+                        .recruitCondition(rc)
+                        .jobCondition(jc)
+                        .score(finalScore)
+                        .status(Optional.ofNullable(matchMap.get(jc.getId()))
+                                .map(Match::getStatus)
+                                .orElse(MatchStatus.NONE))
+                        .build();
+                results.add(newScore);
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * 기존에 존재하던 MatchScore 중 이번 점수 재계산 결과에 포함되지 않은 항목을 필터링합니다.
+     * 해당 항목들은 soft-delete 처리를 위해 deletedAt을 설정하여 반환합니다.
+     */
+    private List<MatchScore> filterSoftDeleteTargetsForRecruit(
+            Map<String, MatchScore> existingScoreMap,
+            List<MatchScore> newScores
+    ) {
+        Set<String> processedKeys = newScores.stream()
+                .map(ms -> generateKey(ms.getJobCondition().getId(), ms.getRecruitCondition().getRecruitConditionId()))
+                .collect(Collectors.toSet());
+
+        return existingScoreMap.entrySet().stream()
+                .filter(entry -> !processedKeys.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .filter(ms -> ms.getDeletedAt() == null)
+                .peek(ms -> ms.setDeletedAt(LocalDateTime.now()))
+                .toList();
     }
 
     /**

--- a/src/main/java/com/example/springserver/service/score/service/ScoreCalculationService.java
+++ b/src/main/java/com/example/springserver/service/score/service/ScoreCalculationService.java
@@ -15,15 +15,16 @@ import com.example.springserver.global.apiPayload.format.ErrorCode;
 import com.example.springserver.global.apiPayload.format.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class ScoreCalculationService {
 
     private final JobConditionRepository jobConditionRepository;
@@ -32,18 +33,23 @@ public class ScoreCalculationService {
     private final ScoreRepository scoreRepository;
 
     // 주기적 삭제
+    /**
+     * 주기적으로 스케줄러에서 호출되는 메서드입니다.
+     * deledted_at 이 NULL 이 아니라면 삭제하는 메서드입니다.
+     */
     @Transactional
     public void summarize() {
         scoreRepository.deleteAllMarkedAsDeleted();
     }
 
-    // RC 변경시 Update
+    /**
+     *  RC 변경시 점수 재계산 때립니다.
+     *  기존 MatchScore가 존재하면 복구 및 업데이트,
+     *  존재하지 않으면 새로 생성합니다.
+     */
     @Transactional
     public void recalculateScoresForRecruit(Long recruitConditionId) {
-        // 점수 삭제
-        scoreRepository.deleteAllByRecruitConditionId(recruitConditionId);
-
-        // RC + RecruitTimes → Map<Week, Long> 구성
+        // RC 조회 + RecruitTime → 시간 마스킹
         RecruitCondition rc = recruitCondRepository.findById(recruitConditionId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.RECRUIT_NOT_FOUND));
 
@@ -51,18 +57,27 @@ public class ScoreCalculationService {
                 .collect(Collectors.toMap(
                         RecruitTime::getDayOfWeek,
                         rt -> getTimeMask(rt.getStartTime(), rt.getEndTime()),
-                        (a, b) -> a | b  // 같은 요일 여러 개면 OR로 합치기
+                        (a, b) -> a | b
                 ));
 
         int rcDayMask = rcDayTimeMap.keySet().stream()
                 .mapToInt(Week::getBitMask)
                 .reduce(0, (a, b) -> a | b);
 
-        // JC 목록 조회 (지역 기반 필터링)
-        List<JobCondition> candidates = jobConditionRepository.findAllByRecommendedListByElder(rc.getRecruitLocation().getLocationId())
-                .orElseThrow(() -> new GlobalException(ErrorCode.RECOMMEND_LIST_NOT_FOUND));
+        // JC 후보 조회 (지역 기준 필터링)
+        List<JobCondition> candidates = jobConditionRepository.findAllByRecommendedListByElder(
+                rc.getRecruitLocation().getLocationId()
+        ).orElseThrow(() -> new GlobalException(ErrorCode.RECOMMEND_LIST_NOT_FOUND));
 
-        // Match 조회
+        // 기존 MatchScore 모두 불러오기 (soft-delete 포함)
+        List<MatchScore> existingScores = scoreRepository.findAllByRecruitConditionIncludingDeleted(recruitConditionId);
+        Map<String, MatchScore> scoreMap = existingScores.stream()
+                .collect(Collectors.toMap(
+                        ms -> ms.getJobCondition().getId() + "_" + ms.getRecruitCondition().getRecruitConditionId(),
+                        ms -> ms
+                ));
+
+        // Match 상태 조회
         List<Match> matches = matchRepository.findAllByRecruitCondition_RecruitConditionId(rc.getRecruitConditionId());
         Map<Long, Match> matchMap = matches.stream()
                 .collect(Collectors.toMap(
@@ -79,58 +94,52 @@ public class ScoreCalculationService {
             int timeScore = calculateTimeScore(rcDayTimeMap, jc);
             int finalScore = (conditionScore + timeScore) / 2;
 
-            results.add(MatchScore.builder()
-                    .caregiverName(jc.getCaregiver().getName())
-                    .caregiverImg(jc.getCaregiver().getImg())
-                    .recruitCondition(rc)
-                    .jobCondition(jc)
-                    .score(finalScore)
-                    .status(Optional.ofNullable(matchMap.get(jc.getId()))
-                                    .map(Match::getStatus)
-                                    .orElse(MatchStatus.NONE))
-                    .build());
+            String key = jc.getId() + "_" + rc.getRecruitConditionId();
+
+            if (scoreMap.containsKey(key)) {
+                MatchScore existing = scoreMap.get(key);
+                existing.setScore(finalScore);
+                existing.setStatus(Optional.ofNullable(matchMap.get(jc.getId()))
+                        .map(Match::getStatus)
+                        .orElse(MatchStatus.NONE));
+                existing.setDeletedAt(null);
+                results.add(existing);
+            } else {
+                MatchScore newScore = MatchScore.builder()
+                        .caregiverName(jc.getCaregiver().getName())
+                        .caregiverImg(jc.getCaregiver().getImg())
+                        .recruitCondition(rc)
+                        .jobCondition(jc)
+                        .score(finalScore)
+                        .status(Optional.ofNullable(matchMap.get(jc.getId()))
+                                .map(Match::getStatus)
+                                .orElse(MatchStatus.NONE))
+                        .build();
+                results.add(newScore);
+            }
         }
 
         scoreRepository.saveAll(results);
     }
 
     // JC 변경시 Update
+
+    /**
+     * JC 변경 시 점수 재계산을 수행합니다.
+     * 존재하는 MatchScore는 수정/복구하고, 존재하지 않으면 새로 생성하여 저장합니다.
+     */
     @Transactional
     public void recalculateScoresForJob(Long jobConditionId) {
+        JobCondition jc = fetchJobCondition(jobConditionId);
+        List<RecruitCondition> rcList = fetchRelatedRecruitConditions(jc);
+        Map<String, MatchScore> existingScoreMap = fetchExistingMatchScoreMap(jobConditionId);
 
-        // 점수 삭제
-        scoreRepository.deleteAllByJobConditionId(jobConditionId);
-
-        // JC 조회
-        JobCondition jc = jobConditionRepository.findById(jobConditionId)
-                .orElseThrow(() -> new GlobalException(ErrorCode.JOB_CONDITION_NOT_FOUND));
-
-        // JC가 가능한 지역에 있는 RC 후보들 조회
-        List<Long> locationIds = jc.getWorkLocations().stream()
-                .map(wl -> wl.getLocationId().getLocationId())
-                .toList();
-
-        List<RecruitCondition> rcList = recruitCondRepository.findAllByRecruitLocation_LocationIdIn(locationIds);
-
-        // 점수 계산
         List<MatchScore> results = new ArrayList<>();
 
         for (RecruitCondition rc : rcList) {
-            List<RecruitTime> rts = rc.getRecruitTimes();
+            Map<Week, Long> rcDayTimeMap = buildRcDayTimeMap(rc.getRecruitTimes());
 
-            // RecruitTime → Map<Week, Long>으로 변환
-            Map<Week, Long> rcDayTimeMap = rts.stream()
-                    .collect(Collectors.toMap(
-                            RecruitTime::getDayOfWeek,
-                            rt -> getTimeMask(rt.getStartTime(), rt.getEndTime()),
-                            (a, b) -> a | b
-                    ));
-
-            int rcDayMask = rcDayTimeMap.keySet().stream()
-                    .mapToInt(Week::getBitMask)
-                    .reduce(0, (a, b) -> a | b);
-
-            if ((jc.getDayOfWeek() & rcDayMask) == 0) continue;
+            if (!isAvailableOnSameDay(jc, rcDayTimeMap)) continue;
 
             int conditionScore = calculateConditionScore(jc, rc);
             int timeScore = calculateTimeScore(rcDayTimeMap, jc);
@@ -139,22 +148,126 @@ public class ScoreCalculationService {
             MatchStatus match = matchRepository.findByJobCondition_IdAndRecruitCondition_Id(
                     rc.getRecruitConditionId(), jc.getId());
 
-            results.add(MatchScore.builder()
-                    .caregiverName(jc.getCaregiver().getName())
-                    .caregiverImg(jc.getCaregiver().getImg())
-                    .recruitCondition(rc)
-                    .score(finalScore)
-                    .status(match != null ? match : MatchStatus.NONE)
-                    .build());
+            String key = generateKey(jc.getId(), rc.getRecruitConditionId());
+
+            if (existingScoreMap.containsKey(key)) {
+                MatchScore updated = updateExistingScore(existingScoreMap.get(key), match, finalScore);
+                results.add(updated);
+            } else {
+                MatchScore created = createNewScore(jc, rc, finalScore, match);
+                results.add(created);
+            }
         }
 
         scoreRepository.saveAll(results);
     }
 
-    private int calculateConditionScore(JobCondition jc,RecruitCondition rc) {
+    /**
+     * JC ID로 JobCondition을 조회합니다.
+     * 존재하지 않으면 예외를 발생시킵니다.
+     */
+    private JobCondition fetchJobCondition(Long jobConditionId) {
+        return jobConditionRepository.findById(jobConditionId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.JOB_CONDITION_NOT_FOUND));
+    }
+
+    /**
+     * JC가 가능한 지역 기반으로 관련 RecruitCondition을 조회합니다.
+     */
+    private List<RecruitCondition> fetchRelatedRecruitConditions(JobCondition jc) {
+        List<Long> locationIds = jc.getWorkLocations().stream()
+                .map(wl -> wl.getLocationId().getLocationId())
+                .toList();
+        return recruitCondRepository.findAllByRecruitLocation_LocationIdIn(locationIds);
+    }
+
+    /**
+     * soft-delete 포함하여, 해당 JobCondition과 관련된 모든 MatchScore를 Map 형태로 조회합니다.
+     */
+    private Map<String, MatchScore> fetchExistingMatchScoreMap(Long jobConditionId) {
+        List<MatchScore> scores = scoreRepository.findAllByJobConditionIncludingDeleted(jobConditionId);
+        return scores.stream().collect(Collectors.toMap(
+                ms -> generateKey(ms.getJobCondition().getId(), ms.getRecruitCondition().getRecruitConditionId()),
+                ms -> ms
+        ));
+    }
+
+    /**
+     * RecruitTime 리스트로부터 요일-비트마스크 맵을 생성합니다.
+     */
+    private Map<Week, Long> buildRcDayTimeMap(List<RecruitTime> recruitTimes) {
+        return recruitTimes.stream()
+                .collect(Collectors.toMap(
+                        RecruitTime::getDayOfWeek,
+                        rt -> getTimeMask(rt.getStartTime(), rt.getEndTime()),
+                        (a, b) -> a | b
+                ));
+    }
+
+    /**
+     * JC와 RC가 가능한 요일이 하나라도 겹치는지 확인합니다.
+     */
+    private boolean isAvailableOnSameDay(JobCondition jc, Map<Week, Long> rcDayTimeMap) {
+        int rcDayMask = rcDayTimeMap.keySet().stream()
+                .mapToInt(Week::getBitMask)
+                .reduce(0, (a, b) -> a | b);
+        return (jc.getDayOfWeek() & rcDayMask) != 0;
+    }
+
+    /**
+     * MatchScore를 새로 생성합니다.
+     */
+    private MatchScore createNewScore(JobCondition jc, RecruitCondition rc, int score, MatchStatus match) {
+        return MatchScore.builder()
+                .caregiverName(jc.getCaregiver().getName())
+                .caregiverImg(jc.getCaregiver().getImg())
+                .recruitCondition(rc)
+                .jobCondition(jc)
+                .score(score)
+                .status(match != null ? match : MatchStatus.NONE)
+                .build();
+    }
+
+    /**
+     * 기존 MatchScore를 업데이트 및 복원(soft-delete 해제)합니다.
+     */
+    private MatchScore updateExistingScore(MatchScore existing, MatchStatus match, int newScore) {
+        existing.setScore(newScore);
+        existing.setStatus(match != null ? match : MatchStatus.NONE);
+        existing.setDeletedAt(null); // 복원
+        return existing;
+    }
+
+    /**
+     * jobConditionId와 recruitConditionId로 고유 key를 생성합니다.
+     */
+    private String generateKey(Long jobConditionId, Long recruitConditionId) {
+        return jobConditionId + "_" + recruitConditionId;
+    }
+
+
+    /**
+     * 여기를 @Transactional로 나눴더니 Update/Delete Transactional 안씌워지는 오류 해결되더라구요
+     * 여기 통해서 점수계산 Transactional 씌워서 들어가게되요
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recalculateScoresForJobWithNewTransaction(Long id) {
+        recalculateScoresForJob(id);
+    }
+
+    /**
+     * 여기를 @Transactional로 나눴더니 Update/Delete Transactional 안씌워지는 오류 해결되더라구요
+     * 여기 통해서 점수계산 Transactional 씌워서 들어가게되요
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recalculateScoresForRecruitWithNewTransaction(Long recruitConditionId) {
+        recalculateScoresForRecruit(recruitConditionId);
+    }
+
+    private int calculateConditionScore(JobCondition jc, RecruitCondition rc) {
         int totalScore = 100; // 기본 점수
 
-        // 체크할 필드 목록 (getter 메서드 이름을 기반으로 자동 체크)
+        // 체크할 필드 목록
         List<String> conditionFields = List.of(
                 "SelfFeeding", "MealPreparation", "CookingAssistance", "EnteralNutritionSupport",
                 "SelfToileting", "OccasionalToiletingAssist", "DiaperCare", "CatheterOrStomaCare",
@@ -163,53 +276,113 @@ public class ScoreCalculationService {
                 "ExerciseSupport", "EmotionalSupport", "CognitiveStimulation"
         );
 
-        try {
-            for (String field : conditionFields) {
-                Method jcMethod = JobCondition.class.getMethod("get" + field);
-                Method rcMethod = RecruitCondition.class.getMethod("is" + field);
-
-                ScheduleAvailability jcValue = (ScheduleAvailability) jcMethod.invoke(jc);
-                boolean rcValue = (boolean) rcMethod.invoke(rc);
-
-                if (jcValue == ScheduleAvailability.IMPOSSIBLE && rcValue) {
-                    totalScore -= 20;
-                } else if (jcValue == ScheduleAvailability.NEGOTIABLE) {
-                    totalScore -= 2;
-                }
-            }
-        } catch (Exception e) {
-            throw new GlobalException(ErrorCode.ERROR_AT_CALCULATE_LOGIC);
+        for (String field : conditionFields) {
+            totalScore = updateScoreBasedOnCondition(jc, rc, field, totalScore);
         }
+
         return Math.max(0, totalScore);
     }
 
+    /**
+     * 필드에 따른 점수를 업데이트합니다.
+     */
+    private int updateScoreBasedOnCondition(JobCondition jc, RecruitCondition rc, String field, int totalScore) {
+        try {
+            // 필드별 getter 메서드 호출
+            ScheduleAvailability jcValue = getJobConditionFieldValue(jc, field);
+            boolean rcValue = getRecruitConditionFieldValue(rc, field);
+
+            // 점수 계산
+            return calculateScoreForField(jcValue, rcValue, totalScore);
+        } catch (Exception e) {
+            throw new GlobalException(ErrorCode.ERROR_AT_CALCULATE_LOGIC);
+        }
+    }
+
+    /**
+     * JobCondition에서 해당 필드 값을 가져옵니다.
+     */
+    private ScheduleAvailability getJobConditionFieldValue(JobCondition jc, String field) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        Method jcMethod = JobCondition.class.getMethod("get" + field);
+        return (ScheduleAvailability) jcMethod.invoke(jc);
+    }
+
+    /**
+     * RecruitCondition에서 해당 필드 값을 가져옵니다.
+     */
+    private boolean getRecruitConditionFieldValue(RecruitCondition rc, String field) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        Method rcMethod = RecruitCondition.class.getMethod("is" + field);
+        return (boolean) rcMethod.invoke(rc);
+    }
+
+    /**
+     * 해당 필드의 조건에 맞춰 점수를 계산합니다.
+     */
+    private int calculateScoreForField(ScheduleAvailability jcValue, boolean rcValue, int totalScore) {
+        if (jcValue == ScheduleAvailability.IMPOSSIBLE && rcValue) {
+            totalScore -= 20; // 불가능한 조건에 맞을 때 20점 차감
+        } else if (jcValue == ScheduleAvailability.NEGOTIABLE) {
+            totalScore -= 2; // 조정 가능한 조건에 맞을 때 2점 차감
+        }
+        return totalScore;
+    }
+
+    /**
+     * 시간 점수 계산 로직입니다.
+     */
     private int calculateTimeScore(Map<Week, Long> rcDayTimeMap, JobCondition jc) {
         int totalScore = 0;
         int matchedDays = 0;
 
+        // JC의 시간 마스크 가져오기
         long jcTimeMask = getTimeMask(jc.getStartTime(), jc.getEndTime());
 
+        // RC의 시간 마스크와 비교하여 점수 계산
         for (Map.Entry<Week, Long> entry : rcDayTimeMap.entrySet()) {
             Week rcDay = entry.getKey();
             long rcTimeMask = entry.getValue();
 
-            // 요일이 겹치는지 확인
-            if ((jc.getDayOfWeek() & rcDay.getBitMask()) == 0) continue;
-
-            matchedDays++;
-
-            long overlapped = jcTimeMask & rcTimeMask;
-
-            int overlapCount = Long.bitCount(overlapped);
-            int rcCount = Long.bitCount(rcTimeMask);
-
-            int score = (int)((overlapCount / (double) rcCount) * 100);
-            totalScore += score;
+            if (isDayMatched(jc, rcDay)) {
+                matchedDays++;
+                int score = calculateDayScore(jcTimeMask, rcTimeMask);
+                totalScore += score;
+            }
         }
 
+        return calculateAverageScore(matchedDays, totalScore);
+    }
+
+    /**
+     * 요일이 일치하면 True 아니면 False 반환합니다.
+     */
+    private boolean isDayMatched(JobCondition jc, Week rcDay) {
+        return (jc.getDayOfWeek() & rcDay.getBitMask()) != 0;
+    }
+
+    /**
+     * 하루의 시간 겹침 정도에 따른 점수 계산해서 반환합니다. (비트마스킹비교)
+     */
+    private int calculateDayScore(long jcTimeMask, long rcTimeMask) {
+        long overlapped = jcTimeMask & rcTimeMask;
+        int overlapCount = Long.bitCount(overlapped);
+        int rcCount = Long.bitCount(rcTimeMask);
+
+        return (int)((overlapCount / (double) rcCount) * 100);
+    }
+
+    /**
+     * 최종 점수 계산 (평균 점수)
+     */
+    private int calculateAverageScore(int matchedDays, int totalScore) {
         return (matchedDays > 0) ? (totalScore / matchedDays) : 0;
     }
 
+    /**
+     * TimeMask로 변환하는 method 입니다.
+     * startTime과 endTime 들어가면
+     * 0000111111111100000
+     * 처럼 시간대 체크된건 1로 표시되어서 반환됩니다.
+     */
     private Long getTimeMask(Long startTime, Long endTime) {
         long mask = 0;
         for (Long i = startTime; i < endTime; i++) {

--- a/src/main/java/com/example/springserver/service/score/service/ScoreCalculationService.java
+++ b/src/main/java/com/example/springserver/service/score/service/ScoreCalculationService.java
@@ -1,0 +1,220 @@
+package com.example.springserver.service.score.service;
+
+import com.example.springserver.domain.caregiver.entity.JobCondition;
+import com.example.springserver.domain.caregiver.entity.enums.ScheduleAvailability;
+import com.example.springserver.domain.caregiver.repository.JobConditionRepository;
+import com.example.springserver.domain.center.entity.*;
+import com.example.springserver.domain.center.entity.enums.Week;
+import com.example.springserver.domain.center.repository.MatchRepository;
+import com.example.springserver.domain.center.repository.RecruitCondRepository;
+import com.example.springserver.domain.match.entity.Match;
+import com.example.springserver.domain.match.entity.enums.MatchStatus;
+import com.example.springserver.domain.score.entity.MatchScore;
+import com.example.springserver.domain.score.repository.ScoreRepository;
+import com.example.springserver.global.apiPayload.format.ErrorCode;
+import com.example.springserver.global.apiPayload.format.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScoreCalculationService {
+
+    private final JobConditionRepository jobConditionRepository;
+    private final RecruitCondRepository recruitCondRepository;
+    private final MatchRepository matchRepository;
+    private final ScoreRepository scoreRepository;
+
+    // 주기적 삭제
+    @Transactional
+    public void summarize() {
+        scoreRepository.deleteAllMarkedAsDeleted();
+    }
+
+    // RC 변경시 Update
+    @Transactional
+    public void recalculateScoresForRecruit(Long recruitConditionId) {
+        // 점수 삭제
+        scoreRepository.deleteAllByRecruitConditionId(recruitConditionId);
+
+        // RC + RecruitTimes → Map<Week, Long> 구성
+        RecruitCondition rc = recruitCondRepository.findById(recruitConditionId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.RECRUIT_NOT_FOUND));
+
+        Map<Week, Long> rcDayTimeMap = rc.getRecruitTimes().stream()
+                .collect(Collectors.toMap(
+                        RecruitTime::getDayOfWeek,
+                        rt -> getTimeMask(rt.getStartTime(), rt.getEndTime()),
+                        (a, b) -> a | b  // 같은 요일 여러 개면 OR로 합치기
+                ));
+
+        int rcDayMask = rcDayTimeMap.keySet().stream()
+                .mapToInt(Week::getBitMask)
+                .reduce(0, (a, b) -> a | b);
+
+        // JC 목록 조회 (지역 기반 필터링)
+        List<JobCondition> candidates = jobConditionRepository.findAllByRecommendedListByElder(rc.getRecruitLocation().getLocationId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.RECOMMEND_LIST_NOT_FOUND));
+
+        // Match 조회
+        List<Match> matches = matchRepository.findAllByRecruitCondition_RecruitConditionId(rc.getRecruitConditionId());
+        Map<Long, Match> matchMap = matches.stream()
+                .collect(Collectors.toMap(
+                        m -> m.getJobCondition().getId(),
+                        m -> m
+                ));
+
+        List<MatchScore> results = new ArrayList<>();
+
+        for (JobCondition jc : candidates) {
+            if ((jc.getDayOfWeek() & rcDayMask) == 0) continue;
+
+            int conditionScore = calculateConditionScore(jc, rc);
+            int timeScore = calculateTimeScore(rcDayTimeMap, jc);
+            int finalScore = (conditionScore + timeScore) / 2;
+
+            results.add(MatchScore.builder()
+                    .caregiverName(jc.getCaregiver().getName())
+                    .caregiverImg(jc.getCaregiver().getImg())
+                    .recruitCondition(rc)
+                    .jobCondition(jc)
+                    .score(finalScore)
+                    .status(Optional.ofNullable(matchMap.get(jc.getId()))
+                                    .map(Match::getStatus)
+                                    .orElse(MatchStatus.NONE))
+                    .build());
+        }
+
+        scoreRepository.saveAll(results);
+    }
+
+    // JC 변경시 Update
+    @Transactional
+    public void recalculateScoresForJob(Long jobConditionId) {
+
+        // 점수 삭제
+        scoreRepository.deleteAllByJobConditionId(jobConditionId);
+
+        // JC 조회
+        JobCondition jc = jobConditionRepository.findById(jobConditionId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.JOB_CONDITION_NOT_FOUND));
+
+        // JC가 가능한 지역에 있는 RC 후보들 조회
+        List<Long> locationIds = jc.getWorkLocations().stream()
+                .map(wl -> wl.getLocationId().getLocationId())
+                .toList();
+
+        List<RecruitCondition> rcList = recruitCondRepository.findAllByRecruitLocation_LocationIdIn(locationIds);
+
+        // 점수 계산
+        List<MatchScore> results = new ArrayList<>();
+
+        for (RecruitCondition rc : rcList) {
+            List<RecruitTime> rts = rc.getRecruitTimes();
+
+            // RecruitTime → Map<Week, Long>으로 변환
+            Map<Week, Long> rcDayTimeMap = rts.stream()
+                    .collect(Collectors.toMap(
+                            RecruitTime::getDayOfWeek,
+                            rt -> getTimeMask(rt.getStartTime(), rt.getEndTime()),
+                            (a, b) -> a | b
+                    ));
+
+            int rcDayMask = rcDayTimeMap.keySet().stream()
+                    .mapToInt(Week::getBitMask)
+                    .reduce(0, (a, b) -> a | b);
+
+            if ((jc.getDayOfWeek() & rcDayMask) == 0) continue;
+
+            int conditionScore = calculateConditionScore(jc, rc);
+            int timeScore = calculateTimeScore(rcDayTimeMap, jc);
+            int finalScore = (conditionScore + timeScore) / 2;
+
+            MatchStatus match = matchRepository.findByJobCondition_IdAndRecruitCondition_Id(
+                    rc.getRecruitConditionId(), jc.getId());
+
+            results.add(MatchScore.builder()
+                    .caregiverName(jc.getCaregiver().getName())
+                    .caregiverImg(jc.getCaregiver().getImg())
+                    .recruitCondition(rc)
+                    .score(finalScore)
+                    .status(match != null ? match : MatchStatus.NONE)
+                    .build());
+        }
+
+        scoreRepository.saveAll(results);
+    }
+
+    private int calculateConditionScore(JobCondition jc,RecruitCondition rc) {
+        int totalScore = 100; // 기본 점수
+
+        // 체크할 필드 목록 (getter 메서드 이름을 기반으로 자동 체크)
+        List<String> conditionFields = List.of(
+                "SelfFeeding", "MealPreparation", "CookingAssistance", "EnteralNutritionSupport",
+                "SelfToileting", "OccasionalToiletingAssist", "DiaperCare", "CatheterOrStomaCare",
+                "IndependentMobility", "MobilityAssist", "WheelchairAssist", "Immobile",
+                "CleaningLaundryAssist", "BathingAssist", "HospitalAccompaniment",
+                "ExerciseSupport", "EmotionalSupport", "CognitiveStimulation"
+        );
+
+        try {
+            for (String field : conditionFields) {
+                Method jcMethod = JobCondition.class.getMethod("get" + field);
+                Method rcMethod = RecruitCondition.class.getMethod("is" + field);
+
+                ScheduleAvailability jcValue = (ScheduleAvailability) jcMethod.invoke(jc);
+                boolean rcValue = (boolean) rcMethod.invoke(rc);
+
+                if (jcValue == ScheduleAvailability.IMPOSSIBLE && rcValue) {
+                    totalScore -= 20;
+                } else if (jcValue == ScheduleAvailability.NEGOTIABLE) {
+                    totalScore -= 2;
+                }
+            }
+        } catch (Exception e) {
+            throw new GlobalException(ErrorCode.ERROR_AT_CALCULATE_LOGIC);
+        }
+        return Math.max(0, totalScore);
+    }
+
+    private int calculateTimeScore(Map<Week, Long> rcDayTimeMap, JobCondition jc) {
+        int totalScore = 0;
+        int matchedDays = 0;
+
+        long jcTimeMask = getTimeMask(jc.getStartTime(), jc.getEndTime());
+
+        for (Map.Entry<Week, Long> entry : rcDayTimeMap.entrySet()) {
+            Week rcDay = entry.getKey();
+            long rcTimeMask = entry.getValue();
+
+            // 요일이 겹치는지 확인
+            if ((jc.getDayOfWeek() & rcDay.getBitMask()) == 0) continue;
+
+            matchedDays++;
+
+            long overlapped = jcTimeMask & rcTimeMask;
+
+            int overlapCount = Long.bitCount(overlapped);
+            int rcCount = Long.bitCount(rcTimeMask);
+
+            int score = (int)((overlapCount / (double) rcCount) * 100);
+            totalScore += score;
+        }
+
+        return (matchedDays > 0) ? (totalScore / matchedDays) : 0;
+    }
+
+    private Long getTimeMask(Long startTime, Long endTime) {
+        long mask = 0;
+        for (Long i = startTime; i < endTime; i++) {
+            mask |= (1L << i);
+        }
+        return mask;
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/springdb
     username: root
-    password: 1234
+    password: 9702
 
   jpa:
     hibernate:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,11 +17,13 @@ spring:
     defer-datasource-initialization: true # data.sql 실행을 테이블 생성이후로 지연https://petstore.swagger.io/v2/swagger.json
 
 
-#    sql:
-#      init:
-#        mode: always
+#   여기 한칸씩 밀렸더라구요 그래서 실행안되는 경우도 있더라구요
+
+#  sql:
+#    init:
+#      mode: always
 #
-#        data-locations: classpath:/data.sql, classpath:/center.sql
+#      data-locations: classpath:/data.sql, classpath:/center.sql
 
   jwt:
     secret: qo0ZNtzizpcWq/E+Ou/FN8rcYDaycVNolSpOYhIPOOM=

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,6 +3,7 @@ spring:
     name: SpringServer
 
   datasource:
+
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ENC(ABqPb8zpG5FCvSB2CiqLc0svq0Qmh7Wkgk1wYlJJEqMi3sULrdp1Hd2XrLsL6tK2Gnt2SW9nv49Rj86I1ftb13LmdPhd19BM4plbeTrnznna7Q/eIr7gwhJ4n5JuyfzW)
     username: ENC(LAdrT9uRSsMhF4WuzP6tzA==)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: prod
+    active: local
 server:
   port: 8080
   address: 0.0.0.0


### PR DESCRIPTION
# 💡 Issue
- close #118 


# 🌱 Key changes

### Event, Score, Scheduler 전반의 작업 끝
- [x] Score Domain 생성
- [x] Score Scheduler 구현
- [x] RC,JC  변경시 Score upsert 로직 구현
- [x] Score upsert 시 soft-delete 안되는 Bug 수정
- [x] ScoreCalculateService 메서드 분할 및 주석달기 리팩토링

# ✅ To Reviewers

<div align="center">
  <table>
    <tr>
      <td align="center">
        <img src="https://github.com/geishaz.png" width="100" />
      </td>
    </tr>
    <tr>
      <td align="center">
        <img src="https://img.shields.io/badge/담당자-정민호-blue" />
      </td>
    </tr>
  </table>
</div>



## **ScoreCalculationService - JC 및 RC 변경 시 처리 흐름 설명**

### **1. 개요**
ScoreCalculationService는 요양보호사(JobCondition)와 복지센터의 구인 조건(RecruitCondition) 간의 **적합도 점수(MatchScore)** 를 계산하고 관리하는 서비스입니다.

본 서비스는 다음 두 가지 상황에 대응하여 점수를 재계산하고 저장합니다:

- **JobCondition(JC)가 변경된 경우**
- **RecruitCondition(RC)가 변경된 경우**

각 변경 상황마다 점수를 새로 계산하고, 이전 점수와 비교하여 **갱신 또는 soft-delete 처리**를 수행합니다.

---

### **2. 공통적인 처리 목적**

- **MatchScore가 최신 상태를 반영하도록 유지**합니다.
- 변경된 조건에 따라 **유효하지 않게 된 MatchScore는 soft-delete 처리**합니다.
- 이미 존재하는 점수는 **복구(update)** 하고, 새로 필요한 점수는 **생성(create)** 합니다.

---

### **3. JC 변경 시 발생하는 일**

### **호출 메서드:**

### **recalculateScoresForJob(Long jobConditionId)**

**JobCondition(요양보호사 조건)이 변경될 경우**, 다음 흐름으로 점수를 다시 계산합니다:

1. **JobCondition 조회**
    
    전달받은 jobConditionId를 기반으로 JC를 조회합니다.
    
2. **가능한 지역에 해당하는 RecruitCondition 조회**
    
    JC가 희망하는 근무 지역을 기준으로 관련 RecruitCondition을 모두 가져옵니다.
    
3. **각 RecruitCondition에 대해 다음을 수행합니다:**
    - 요일 및 시간 겹침 여부 확인
    - 구인/구직 조건 일치율 계산
    - 시간대 겹침 점수 계산
    - 위 두 점수를 평균 내 최종 점수 산출
4. **기존 MatchScore와 비교하여**
    - 존재하면 → 점수/상태 갱신 + soft-delete 복구
    - 없으면 → 새로 생성
5. **이제 유효하지 않은 기존 MatchScore들을 soft-delete 처리**
    - 예: JC의 지역이 바뀌어 기존 RC들과 더 이상 매칭되지 않는 경우
6. **결과 저장**
    
    모든 업데이트/생성/삭제 대상 MatchScore를 saveAll로 일괄 저장합니다.
    

---

### **4. RC 변경 시 발생하는 일**

### **호출 메서드:**

### **recalculateScoresForRecruit(Long recruitConditionId)**

**RecruitCondition(복지센터의 구인 조건)이 변경될 경우**, 다음 흐름으로 점수를 다시 계산합니다:

1. **RecruitCondition 조회**
    
    전달받은 recruitConditionId를 기반으로 RC를 조회합니다.
    
2. **RecruitTime을 기반으로 요일/시간 마스크 계산**
    
    → 근무 가능한 요일 및 시간대를 비트마스크로 구성합니다.
    
3. **해당 지역(JobCondition 기준)에 추천 가능한 요양보호사 후보 조회**
4. **각 JobCondition에 대해 다음을 수행합니다:**
    - 요일 겹침 확인 (한 요일이라도 겹쳐야 진행)
    - 구인/구직 조건 일치율 계산
    - 시간대 겹침 점수 계산
    - 두 점수를 평균 내 최종 점수 산출
5. **기존 MatchScore와 비교하여**
    - 존재하면 → 점수/상태 갱신 + soft-delete 복구
    - 없으면 → 새로 생성
6. **이제 유효하지 않은 기존 MatchScore들을 soft-delete 처리**
    - 예: RC의 요일이 바뀌어 JC와 더 이상 겹치지 않게 된 경우
7. **결과 저장**
    
    모든 MatchScore들을 일괄 저장합니다.
    

---

### **5. soft-delete란?**

- MatchScore를 물리적으로 삭제하지 않고, deletedAt 값을 설정해 숨기는 방식입니다.
- 이전 기록을 보존하면서도, 현재는 유효하지 않음을 명확하게 표현할 수 있습니다.
- @Where(clause = "deleted_at IS NULL") 등을 통해 조회 시 필터링할 수 있습니다.

---

### **6. 왜 이렇게 설계했나요?**

- **데이터 정합성 유지**: 변경된 조건을 기준으로 항상 최신의 매칭 점수를 유지할 수 있습니다.
- **성능 최적화**: 필요한 경우에만 점수를 계산하며, 일괄 저장 방식으로 DB 접근 최소화
- **확장성 확보**: JC/RC 각각의 변경 상황에 대응하며, 추후 스케줄러 또는 이벤트 기반 확장도 용이합니다.
- **재사용성**: 메서드를 기능별로 분할하여 다른 상황에서도 재사용이 가능하고 테스트도 쉬워집니다.

### 표로 요약
| 변경 상황 | 갱신 대상    | 변경 처리                        | 불필요한 점수 처리  |
|------------|---------------|------------------------------------|----------------------|
| JC 변경    | 관련 RC들     | 점수 계산 & MatchScore 갱신/생성 | soft-delete 처리     |
| RC 변경    | 관련 JC들     | 점수 계산 & MatchScore 갱신/생성 | soft-delete 처리     |



# 📸 스크린샷
