### PR TITLE
refactor: 근무 가능 지역 데이터 캐싱 처리

### DIFF
--- a/src/main/java/com/example/springserver/domain/caregiver/cache/JobConditionCache.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/cache/JobConditionCache.java
@@ -2,7 +2,10 @@ package com.example.springserver.domain.caregiver.cache;
 
 import com.example.springserver.domain.caregiver.entity.enums.ScheduleAvailability;
 import jakarta.persistence.Id;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.redis.core.RedisHash;
 
 import java.io.Serializable;
@@ -46,6 +49,6 @@ public class JobConditionCache implements Serializable {
     private Long startTime;
     private Long endTime;
 
-    private List<Long> workLocationIds;
+    private List<WorkLocationCache> workLocations;
     private Long caregiverId;
 }

--- a/src/main/java/com/example/springserver/domain/caregiver/cache/JobConditionCacheConverter.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/cache/JobConditionCacheConverter.java
@@ -38,9 +38,9 @@ public class JobConditionCacheConverter {
                 .dayOfWeek(jobCondition.getDayOfWeek())
                 .startTime(jobCondition.getStartTime())
                 .endTime(jobCondition.getEndTime())
-                .workLocationIds(
-                        toWorkLocationIdList(jobCondition.getWorkLocations())
-                )
+                .workLocations(jobCondition.getWorkLocations().stream()
+                        .map(JobConditionCacheConverter::toWorkLocationCache)
+                        .collect(Collectors.toList()))
                 .caregiverId(jobCondition.getCaregiver().getId())
                 .build();
     }
@@ -72,24 +72,26 @@ public class JobConditionCacheConverter {
                 .dayOfWeek(String.valueOf(cache.getDayOfWeek()))
                 .startTime(cache.getStartTime())
                 .endTime(cache.getEndTime())
-                .locationResponseDtoList(toLocationResponseDtoList(cache.getWorkLocationIds()))
+                .locationResponseDtoList(toLocationResponseDtoList(cache.getWorkLocations()))
                 .caregiverId(cache.getCaregiverId())
                 .build();
     }
 
-    private static List<JobConditionResponseDto.LocationResponseDTO> toLocationResponseDtoList(List<Long> workLocationIds) {
+    private static List<JobConditionResponseDto.LocationResponseDTO> toLocationResponseDtoList(List<WorkLocationCache> workLocationIds) {
         return workLocationIds.stream()
-                .map(id -> JobConditionResponseDto.LocationResponseDTO.builder()
-                        .workLocationId(id)
-                        .locationName(null) // 캐시에는 name 정보가 없다고 가정
+                .map(w -> JobConditionResponseDto.LocationResponseDTO.builder()
+                        .workLocationId(w.getWorkLocationId())
+                        .locationName(w.getAddress())
                         .build()
                 )
                 .collect(Collectors.toList());
     }
 
-    private static List<Long> toWorkLocationIdList(List<WorkLocation> workLocations) {
-        return workLocations.stream()
-                .map(WorkLocation::getId)
-                .collect(Collectors.toList());
+    private static WorkLocationCache toWorkLocationCache(WorkLocation workLocation) {
+        return WorkLocationCache.builder()
+                .workLocationId(workLocation.getId())
+                .locationId(workLocation.getLocationId().getLocationId())
+                .address(workLocation.getLocationId().getAddress())
+                .build();
     }
 }

--- a/src/main/java/com/example/springserver/domain/caregiver/cache/JobConditionCacheConverter.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/cache/JobConditionCacheConverter.java
@@ -90,8 +90,8 @@ public class JobConditionCacheConverter {
     private static WorkLocationCache toWorkLocationCache(WorkLocation workLocation) {
         return WorkLocationCache.builder()
                 .workLocationId(workLocation.getId())
-                .locationId(workLocation.getLocationId().getLocationId())
-                .address(workLocation.getLocationId().getAddress())
+                .locationId(workLocation.getLocation().getLocationId())
+                .address(workLocation.getLocation().getAddress())
                 .build();
     }
 }

--- a/src/main/java/com/example/springserver/domain/caregiver/cache/JobConditionCacheRepository.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/cache/JobConditionCacheRepository.java
@@ -32,7 +32,7 @@ public class JobConditionCacheRepository {
         String caregiverKey = getCaregiverKey(cache.getCaregiverId());
 
         cacheHelper.saveValue(jobKey, cache, TTL);
-        cacheHelper.saveValue(caregiverKey, cache.getId(), TTL); // caregiverId → jobConditionId 매핑
+        cacheHelper.saveValue(caregiverKey, cache.getId().toString(), TTL); // caregiverId → jobConditionId 매핑
     }
 
     public Optional<JobConditionCache> findByJobConditionId(Long id) {
@@ -40,7 +40,9 @@ public class JobConditionCacheRepository {
     }
 
     public Optional<JobConditionCache> findByCaregiverId(Long caregiverId) {
-        return cacheHelper.get(getCaregiverKey(caregiverId), Long.class)
+        log.info("caregiver_condition key : {}", getCaregiverKey(caregiverId));
+        return cacheHelper.get(getCaregiverKey(caregiverId), String.class)
+                .map(Long::valueOf)
                 .flatMap(this::findByJobConditionId);
     }
 

--- a/src/main/java/com/example/springserver/domain/caregiver/cache/JobConditionCacheRepository.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/cache/JobConditionCacheRepository.java
@@ -1,75 +1,55 @@
 package com.example.springserver.domain.caregiver.cache;
 
+import com.example.springserver.global.cache.RedisCacheHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
 import java.time.Duration;
+import java.util.Optional;
 
 @Slf4j
 @Repository
 @RequiredArgsConstructor
 public class JobConditionCacheRepository {
 
-    private final RedisTemplate<String, Object> redisTemplate;
-    private static final String JOB_CONDITION_CACHE_KEY_PREFIX = "job_condition:";
-    private static final String CARE_GIVER_CACHE_KEY_PREFIX = "care_giver:";
-    private static final Duration TTL = Duration.ofHours(6); // 캐시 유효 시간 설정
+    private final RedisCacheHelper cacheHelper;
 
-    private String getJobConditionKey(Long jobConditionId) {
-        return JOB_CONDITION_CACHE_KEY_PREFIX + jobConditionId;
+    private static final String JOB_CONDITION_KEY_PREFIX = "job_condition:";
+    private static final String CAREGIVER_KEY_PREFIX = "care_giver:";
+    private static final Duration TTL = Duration.ofHours(6);
+
+    private String getJobConditionKey(Long id) {
+        return JOB_CONDITION_KEY_PREFIX + id;
     }
 
     private String getCaregiverKey(Long caregiverId) {
-        return CARE_GIVER_CACHE_KEY_PREFIX + caregiverId;
+        return CAREGIVER_KEY_PREFIX + caregiverId;
     }
 
-    public void save(JobConditionCache jobConditionCache) {
-        String mainKey = getJobConditionKey(jobConditionCache.getId());
-        String subKey = getCaregiverKey(jobConditionCache.getCaregiverId());
+    public void save(JobConditionCache cache) {
+        String jobKey = getJobConditionKey(cache.getId());
+        String caregiverKey = getCaregiverKey(cache.getCaregiverId());
 
-        redisTemplate.opsForValue().set(mainKey, jobConditionCache, TTL);
-        redisTemplate.opsForValue().set(subKey, jobConditionCache.getId(), TTL);
+        cacheHelper.saveValue(jobKey, cache, TTL);
+        cacheHelper.saveValue(caregiverKey, cache.getId(), TTL); // caregiverId → jobConditionId 매핑
     }
 
-    public Optional<JobConditionCache> findByJobConditionId(Long jobConditionId) {
-        String key = getJobConditionKey(jobConditionId);
-        JobConditionCache result = (JobConditionCache) redisTemplate.opsForValue().get(key);
-        return Optional.ofNullable(result);
+    public Optional<JobConditionCache> findByJobConditionId(Long id) {
+        return cacheHelper.get(getJobConditionKey(id), JobConditionCache.class);
     }
 
     public Optional<JobConditionCache> findByCaregiverId(Long caregiverId) {
-        Long jobConditionId = getJobConditionIdFromCache(caregiverId);
-
-        if (jobConditionId == null) {
-            log.warn("[CacheRepository] jobConditionId not exist - caregiverId: {}", caregiverId);
-            return Optional.empty();
-        }
-
-        return findByJobConditionId(jobConditionId);
+        return cacheHelper.get(getCaregiverKey(caregiverId), Long.class)
+                .flatMap(this::findByJobConditionId);
     }
 
     public void deleteByCaregiverId(Long caregiverId) {
-        redisTemplate.delete(getCaregiverKey(caregiverId));
-    }
+        String caregiverKey = getCaregiverKey(caregiverId);
 
-    private Long getJobConditionIdFromCache(Long caregiverKey) {
-        Object value = redisTemplate.opsForValue().get(getCaregiverKey(caregiverKey));
+        cacheHelper.get(caregiverKey, Long.class)
+                .ifPresent(jobConditionId -> cacheHelper.delete(getJobConditionKey(jobConditionId)));
 
-        if (value instanceof Long) {
-            return (Long) value;
-        } else if (value instanceof Integer) {
-            return ((Integer) value).longValue();  // Integer → Long 변환
-        } else if (value instanceof String) {
-            try {
-                return Long.parseLong((String) value); // 문자열로 저장된 경우
-            } catch (NumberFormatException e) {
-                log.warn("[CacheRepository] Cannot parse jobConditionId from string: {}", value);
-            }
-        }
-        log.warn("[CacheRepository] Expected Long but got: {} type", value != null ? value.getClass() : "null");
-        return null;
+        cacheHelper.delete(caregiverKey);
     }
 }

--- a/src/main/java/com/example/springserver/domain/caregiver/cache/WorkLocationCache.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/cache/WorkLocationCache.java
@@ -5,11 +5,13 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class WorkLocationCache {
+public class WorkLocationCache implements Serializable {
     private Long workLocationId;
     private Long locationId;
     private String address;

--- a/src/main/java/com/example/springserver/domain/caregiver/cache/WorkLocationCache.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/cache/WorkLocationCache.java
@@ -1,0 +1,16 @@
+package com.example.springserver.domain.caregiver.cache;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkLocationCache {
+    private Long workLocationId;
+    private Long locationId;
+    private String address;
+}

--- a/src/main/java/com/example/springserver/domain/caregiver/controller/JobConditionController.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/controller/JobConditionController.java
@@ -27,14 +27,14 @@ public class JobConditionController {
     @PostMapping
     public JobConditionResponseDTO createJobCondition(@AuthenticationPrincipal CustomUserDetails user,
                                                                               @RequestBody @Valid JobConditionReqDto request){
-        return jobConditionService.createOrUpdateJobCondition(user,request);
+        return jobConditionService.createJobCondition(user,request);
     }
 
     @Operation(summary = "요양보호사 구직조건수정", description = "Put")
     @PutMapping
     public JobConditionResponseDTO updateJobCondition(@AuthenticationPrincipal CustomUserDetails user,
                                                                            @RequestBody @Valid JobConditionReqDto request){
-        return jobConditionService.createOrUpdateJobCondition(user,request);
+        return jobConditionService.updateJobCondition(user,request);
     }
 
     @Operation(summary = "요양보호사 구직정보조회", description = "Get")

--- a/src/main/java/com/example/springserver/domain/caregiver/converter/JobConditionConverter.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/converter/JobConditionConverter.java
@@ -52,6 +52,7 @@ public class JobConditionConverter {
                 .startTime(saved.getStartTime())
                 .endTime(saved.getEndTime())
                 .locationResponseDtoList(toListResponseDto(saved.getWorkLocations()))
+                .caregiverId(saved.getCaregiver().getId())
                 .build();
     }
 
@@ -98,7 +99,7 @@ public class JobConditionConverter {
                 .locationRequestDTOList(saved.getWorkLocations().stream()
                         .map(dto -> JobConditionResponseDto.LocationResponseDTO.builder()
                                 .workLocationId(dto.getId())
-                                .locationName(locationService.getLocation(dto.getLocationId().getLocationId()))
+                                .locationName(locationService.getLocation(dto.getLocation().getLocationId()))
                                 .build()
                         )
                         .toList())
@@ -115,7 +116,7 @@ public class JobConditionConverter {
 
         return JobConditionResponseDto.LocationResponseDTO.builder()
                 .workLocationId(location.getId())
-                .locationName(locationService.getLocation(location.getLocationId().getLocationId()))
+                .locationName(locationService.getLocation(location.getLocation().getLocationId()))
                 .build();
     }
 

--- a/src/main/java/com/example/springserver/domain/caregiver/entity/WorkLocation.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/entity/WorkLocation.java
@@ -21,21 +21,21 @@ public class WorkLocation {
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "location_id", nullable = false)
-    private Location locationId;
+    private Location location;
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "job_condition_id", nullable = false)
     private JobCondition jobCondition;
 
-    public WorkLocation(Location locationId, JobCondition jobCondition) {
-        this.locationId = locationId;
+    public WorkLocation(Location location, JobCondition jobCondition) {
+        this.location = location;
         this.jobCondition = jobCondition;
     }
 
-    public WorkLocation(JobCondition jobCondition, Location locationId) {
+    public WorkLocation(JobCondition jobCondition, Location location) {
         this.jobCondition = jobCondition;
-        this.locationId = locationId;
+        this.location = location;
     }
 
     public void setJobCondition(JobCondition jobCondition) {

--- a/src/main/java/com/example/springserver/domain/caregiver/repository/JobConditionRepository.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/repository/JobConditionRepository.java
@@ -10,7 +10,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface JobConditionRepository extends JpaRepository<JobCondition,Long> {
+
+    // fetch join으로 수정
     Optional<JobCondition> findByCaregiver(Caregiver caregiver);
+
+    boolean existsById(Long id);
 
     @Query(value = """
         SELECT jc.*

--- a/src/main/java/com/example/springserver/domain/caregiver/service/JobConditionService.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/service/JobConditionService.java
@@ -49,71 +49,35 @@ public class JobConditionService {
     이제 EventListener 가시면됩니다. -> ScoreRecalculateEventListener
      */
     @Transactional
-    public JobConditionResponseDTO createOrUpdateJobCondition(CustomUserDetails user, JobConditionReqDto request) {
+    public JobConditionResponseDTO createJobCondition(CustomUserDetails user, JobConditionReqDto request) {
         Caregiver caregiver = commonService.getById(user);
-        Long caregiverId = user.getId();
+        // 캐시 삭제
+        jobConditionCacheService.deleteByCaregiverKey(caregiver.getId());
 
-        // 캐시 데이터 삭제
-        jobConditionCacheService.deleteByCaregiverKey(caregiverId);
-
-        JobCondition jobcondition = jobConditionRepository.findByCaregiver(caregiver)
-                .map(existingJobCondition -> updateJobCondition(caregiver, request)) // 존재하면 업데이트
-                .orElseGet(() -> createJobCondition(caregiver, request));// 없으면 새로 생성
-
-        JobConditionResponseDTO jcDto = JobConditionConverter.tojobConditionResponseDTO(jobcondition);
-
-        log.info("event 처리에 활용돠는 jobConditionId = {}", jcDto.getJobConditionId());
-        eventPublisher.publishEvent(new JobConditionChangedEvent(this, jcDto.getJobConditionId()));
-
-        // 캐시 저장
-        JobConditionCache cacheData = JobConditionCacheConverter.toRedisDto(jobcondition);
-        jobConditionCacheService.save(cacheData);
-
-        return jcDto;
-    }
-
-    public JobCondition createJobCondition(Caregiver user, JobConditionReqDto request) {
-
-        JobCondition jobCondition = JobConditionConverter.from(user, request);
-
-        // save
+        // 생성
+        JobCondition jobCondition = JobConditionConverter.from(caregiver, request);
         jobCondition = jobConditionRepository.save(jobCondition);
+
         saveLocations(request, jobCondition);
 
-        return jobCondition;
+        return postProcess(jobCondition);
     }
 
-    public JobCondition updateJobCondition(Caregiver user, JobConditionReqDto request) {
-        JobCondition jobCondition = findJobCondition(user);
+    @Transactional
+    public JobConditionResponseDTO updateJobCondition(CustomUserDetails userDetails, JobConditionReqDto request) {
+        Caregiver caregiver = commonService.getById(userDetails);
+        Long caregiverId = caregiver.getId();
 
-        Set<Long> updatedIds = new HashSet<>();
+        jobConditionCacheService.deleteByCaregiverKey(caregiverId);
 
-        for (JobConditionRequestDto.LocationRequestDTO dto : request.getLocationRequestDTOList()) {
-            Location location = locationService.findById(dto.getLocationId());
-
-            if (dto.getWorkLocationId() != null) {
-                WorkLocation existing = jobCondition.getWorkLocations().stream()
-                        .filter(wl -> wl.getId().equals(dto.getWorkLocationId()))
-                        .findFirst()
-                        .orElseThrow(() -> new GlobalException(ErrorCode.WORK_LOCATION_NOT_FOUND));
-
-                existing.setLocationId(location);
-                updatedIds.add(existing.getId());
-            }
-            else {
-                WorkLocation newLocation = WorkLocation.builder()
-                        .locationId(location)
-                        .jobCondition(jobCondition)
-                        .build();
-                jobCondition.addWokLocation(newLocation);
-            }
-        }
-
-        jobCondition.getWorkLocations().removeIf(wl -> !updatedIds.contains(wl.getId()));
+        JobCondition jobCondition = jobConditionRepository.findByCaregiver(caregiver)
+                .orElseThrow(() -> new GlobalException(ErrorCode.JOB_CONDITION_NOT_FOUND));
 
         jobCondition.updateInfo(request);
+        updateWorkLocations(jobCondition, request);
+        jobCondition = jobConditionRepository.save(jobCondition);
 
-        return jobCondition;
+        return postProcess(jobCondition);
     }
 
     public void saveLocations(JobConditionReqDto request, JobCondition jobCondition) {
@@ -123,13 +87,37 @@ public class JobConditionService {
                     Location location = locationService.findById(dto.getLocationId());
                     return WorkLocation.builder()
                             .jobCondition(jobCondition)
-                            .locationId(location)
+                            .location(location)
                             .build();
                 })
                 .toList();
 
         workLocationRepository.saveAll(workLocations);
         jobCondition.setWorkLocations(workLocations);
+    }
+
+    private void updateWorkLocations(JobCondition jobCondition, JobConditionReqDto request) {
+        List<Long> locationIds = request.getLocationRequestDTOList().stream()
+                .map(JobConditionRequestDto.LocationRequestDTO::getLocationId)
+                .toList();
+
+        Set<Location> requestedLocations = new HashSet<>(locationService.findAllById(locationIds));
+        List<WorkLocation> currentLocations = jobCondition.getWorkLocations();
+
+        // 기존에 없는 새로운 Location만 추가
+        for (Location location : requestedLocations) {
+            boolean alreadyExists = currentLocations.stream()
+                    .anyMatch(wl -> wl.getLocation().getLocationId().equals(location.getLocationId())); // 수정 포인트
+
+            if (!alreadyExists) {
+                WorkLocation workLocation = WorkLocation.builder()
+                        .jobCondition(jobCondition)
+                        .location(location)
+                        .build();
+                workLocationRepository.save(workLocation);
+                jobCondition.addWokLocation(workLocation);  // 양방향 연관관계 설정
+            }
+        }
     }
 
     public DetailJobConditionResponseDTO getDetailedJobCondition(CustomUserDetails user) {
@@ -139,6 +127,7 @@ public class JobConditionService {
     }
 
     // read-through 캐싱 전략이 적용된 조회 코드
+    @Transactional(readOnly = true)
     public JobConditionResponseDTO getJobCondition(CustomUserDetails user) {
         try {
             JobConditionCache cachedJc = jobConditionCacheService.getByCaregiverKey(user.getId());
@@ -162,5 +151,20 @@ public class JobConditionService {
     public JobCondition findJobCondition(Caregiver user) {
         return jobConditionRepository.findByCaregiver(user)
                 .orElseThrow(() -> new GlobalException(ErrorCode.JOB_CONDITION_NOT_FOUND));
+    }
+
+    private JobConditionResponseDTO postProcess(JobCondition jobCondition) {
+        JobConditionResponseDTO jcDto = JobConditionConverter.tojobConditionResponseDTO(jobCondition);
+
+        // 이벤트 발행
+        if (jobCondition.getId() != null) {
+            eventPublisher.publishEvent(new JobConditionChangedEvent(this, jobCondition.getId()));
+        }
+
+        // 캐시 저장
+        JobConditionCache cacheData = JobConditionCacheConverter.toRedisDto(jobCondition);
+        jobConditionCacheService.save(cacheData);
+
+        return jcDto;
     }
 }

--- a/src/main/java/com/example/springserver/domain/caregiver/service/JobConditionService.java
+++ b/src/main/java/com/example/springserver/domain/caregiver/service/JobConditionService.java
@@ -29,7 +29,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -73,7 +72,6 @@ public class JobConditionService {
         return jcDto;
     }
 
-    @Transactional
     public JobCondition createJobCondition(Caregiver user, JobConditionReqDto request) {
 
         JobCondition jobCondition = JobConditionConverter.from(user, request);
@@ -85,7 +83,6 @@ public class JobConditionService {
         return jobCondition;
     }
 
-    @Transactional
     public JobCondition updateJobCondition(Caregiver user, JobConditionReqDto request) {
         JobCondition jobCondition = findJobCondition(user);
 
@@ -119,7 +116,6 @@ public class JobConditionService {
         return jobCondition;
     }
 
-    @Transactional
     public void saveLocations(JobConditionReqDto request, JobCondition jobCondition) {
 
         List<WorkLocation> workLocations = request.getLocationRequestDTOList().stream()
@@ -130,7 +126,7 @@ public class JobConditionService {
                             .locationId(location)
                             .build();
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         workLocationRepository.saveAll(workLocations);
         jobCondition.setWorkLocations(workLocations);

--- a/src/main/java/com/example/springserver/domain/center/cache/RecruitConditionCacheRepository.java
+++ b/src/main/java/com/example/springserver/domain/center/cache/RecruitConditionCacheRepository.java
@@ -1,76 +1,76 @@
 package com.example.springserver.domain.center.cache;
 
+import com.example.springserver.global.cache.RedisCacheHelper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
 public class RecruitConditionCacheRepository {
 
-    private final RedisTemplate<String, Object> redisTemplate;
-    private static final String RECRUIT_CONDITION_HASH_KEY_PREFIX = "recruit_condition:";
-    private static final String ELDER_HASH_KEY_PREFIX = "elder:";
+    private final RedisCacheHelper cacheHelper;
+    private static final String RECRUIT_PREFIX = "recruit_condition:";
+    private static final String ELDER_PREFIX = "elder:";
     private static final Duration TTL = Duration.ofHours(6);
 
-    private String getRecruitConditionHashKey(Long recruitConditionId) {
-        return RECRUIT_CONDITION_HASH_KEY_PREFIX + recruitConditionId;
+    private String getRecruitConditionKey(Long id) {
+        return RECRUIT_PREFIX + id;
     }
 
-    private String getElderListHashKey(Long elderId) {
-        return ELDER_HASH_KEY_PREFIX + elderId + ":recruitConditionIds";
+    private String getElderSetKey(Long elderId) {
+        return ELDER_PREFIX + elderId + ":recruitConditionIds";
     }
 
-    public void save(RecruitConditionCache conditionCache) {
-        String mainKey = getRecruitConditionHashKey(conditionCache.getId());
-        String listKey = getElderListHashKey(conditionCache.getElderId());
+    public void save(RecruitConditionCache cache) {
+        String mainKey = getRecruitConditionKey(cache.getId());
+        String setKey = getElderSetKey(cache.getElderId());
 
-        // 기존 값 삭제
-        redisTemplate.opsForList().remove(listKey, 0, conditionCache.getId());
-        // 저장
-        redisTemplate.opsForValue().set(mainKey, conditionCache, TTL);
-        redisTemplate.opsForList().rightPush(listKey, conditionCache.getId());
-        redisTemplate.expire(listKey, TTL);
+        // 기존 Set에서 제거 후 다시 저장
+        cacheHelper.removeFromSet(setKey, cache.getId().toString());
+        cacheHelper.saveValue(mainKey, cache, TTL);
+        cacheHelper.addToSet(setKey, cache.getId().toString());
     }
 
-    public Optional<RecruitConditionCache> findByRecruitConditionId(Long recruitConditionId) {
-        String key = getRecruitConditionHashKey(recruitConditionId);
-        RecruitConditionCache result = (RecruitConditionCache) redisTemplate.opsForValue().get(key);
-        return Optional.ofNullable(result);
+    public Optional<RecruitConditionCache> findByRecruitConditionId(Long id) {
+        String key = getRecruitConditionKey(id);
+        RecruitConditionCache value = cacheHelper.getValue(key, RecruitConditionCache.class);
+        return Optional.ofNullable(value);
     }
 
     public List<RecruitConditionCache> findByElderId(Long elderId) {
-        String listKey = getElderListHashKey(elderId);
-        List<Object> idList = redisTemplate.opsForList().range(listKey, 0, -1);
+        String setKey = getElderSetKey(elderId);
+        Set<String> ids = cacheHelper.getSet(setKey);
 
-        return idList.stream()
-                .map(id -> findByRecruitConditionId(Long.parseLong(id.toString())))
+        return ids.stream()
+                .map(Long::parseLong)
+                .map(this::findByRecruitConditionId)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .toList();
     }
 
-    public void deleteByRecruitConditionId(Long recruitConditionId) {
-        findByRecruitConditionId(recruitConditionId).ifPresent(cache -> {
-            String listKey = getElderListHashKey(cache.getElderId());
-            redisTemplate.opsForList().remove(listKey, 1, recruitConditionId);
+    public void deleteByRecruitConditionId(Long id) {
+        findByRecruitConditionId(id).ifPresent(cache -> {
+            String setKey = getElderSetKey(cache.getElderId());
+            cacheHelper.removeFromSet(setKey, id.toString());
         });
 
-        redisTemplate.delete(getRecruitConditionHashKey(recruitConditionId));
+        cacheHelper.delete(getRecruitConditionKey(id));
     }
 
     public void deleteAllByElderId(Long elderId) {
-        String listKey = getElderListHashKey(elderId);
-        List<Object> idList = redisTemplate.opsForList().range(listKey, 0, -1);
+        String setKey = getElderSetKey(elderId);
+        Set<String> ids = cacheHelper.getSet(setKey);
 
-        if (idList != null) {
-            idList.forEach(id -> redisTemplate.delete(getRecruitConditionHashKey(Long.parseLong(id.toString()))));
+        for (String id : ids) {
+            cacheHelper.delete(getRecruitConditionKey(Long.parseLong(id)));
         }
 
-        redisTemplate.delete(listKey);
+        cacheHelper.deleteSet(setKey);
     }
 }

--- a/src/main/java/com/example/springserver/domain/location/cache/LocationCache.java
+++ b/src/main/java/com/example/springserver/domain/location/cache/LocationCache.java
@@ -1,0 +1,15 @@
+package com.example.springserver.domain.location.cache;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocationCache {
+    private Long id;
+    private String address;
+}

--- a/src/main/java/com/example/springserver/domain/location/cache/LocationCacheConverter.java
+++ b/src/main/java/com/example/springserver/domain/location/cache/LocationCacheConverter.java
@@ -1,0 +1,13 @@
+package com.example.springserver.domain.location.cache;
+
+import com.example.springserver.domain.location.entity.Location;
+
+public class LocationCacheConverter {
+
+    public static LocationCache toCache(Location location) {
+        return LocationCache.builder()
+                .id(location.getLocationId())
+                .address(location.getAddress())
+                .build();
+    }
+}

--- a/src/main/java/com/example/springserver/domain/location/cache/LocationCacheRepository.java
+++ b/src/main/java/com/example/springserver/domain/location/cache/LocationCacheRepository.java
@@ -1,0 +1,34 @@
+package com.example.springserver.domain.location.cache;
+
+import com.example.springserver.global.cache.RedisCacheHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class LocationCacheRepository {
+
+    private final RedisCacheHelper cacheHelper;
+
+    private static final String KEY_PREFIX = "location:";
+    private static final Duration TTL = Duration.ofDays(30);
+
+    private String getKey(Long id) {
+        return KEY_PREFIX + id;
+    }
+
+    public void save(LocationCache cache) {
+        cacheHelper.saveValue(getKey(cache.getId()), cache, TTL);
+    }
+
+    public Optional<LocationCache> findById(Long id) {
+        return cacheHelper.get(getKey(id), LocationCache.class);
+    }
+
+    public void delete(Long id) {
+        cacheHelper.delete(getKey(id));
+    }
+}

--- a/src/main/java/com/example/springserver/global/apiPayload/format/ErrorCode.java
+++ b/src/main/java/com/example/springserver/global/apiPayload/format/ErrorCode.java
@@ -52,7 +52,7 @@ public enum ErrorCode {
     RECRUIT_CONDITION_CACHE_MISS(HttpStatus.BAD_REQUEST, "RECRUIT_CONDITION_CACHE_MISS4001", "레디스에 해당 구인정보가 캐시되지 않았습니다."),
 
     // 요양보호사 관련 에러
-    JOB_CONDITION_NOT_FOUND(HttpStatus.NOT_FOUND,"JOB_CONDITION_NOTFOUND4001","보호사의 구직정보가 존재하지 않습니다."),
+    JOB_CONDITION_NOT_FOUND(HttpStatus.BAD_REQUEST,"JOB_CONDITION_NOTFOUND4001","보호사의 구직정보가 존재하지 않습니다."),
     JOB_CONDITION_CACHE_MISS(HttpStatus.BAD_REQUEST, "JOB_CONDITION_CACHE_MISS4001", "레디스에 해당 구직정보가 캐시되지 않았습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "CAREGIVER-NOTFOUND4001","보호사정보가 존재하지 않습니다."),
 
@@ -88,10 +88,15 @@ public enum ErrorCode {
     // 매칭 에러
     ERROR_AT_CALCULATE_LOGIC(HttpStatus.NOT_FOUND,"MATCH001", "점수계산중 오류발생" ),
     MONEY_NOT_MATCHED(HttpStatus.BAD_REQUEST,"MATCH002" ,"시급이 일치하지 않습니다."),
+    INTERNAL_SERVER_ERROR_DELETE_MATCH_SCORE(HttpStatus.INTERNAL_SERVER_ERROR, "MATCHSCORE500", "매칭 점수 삭제 중 서버 에러 발생"),
+
+    // 매칭 점수 계산 에러
+    JCSCORE_RECALCULATING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "MATCHSCORE500", "jc 점수 재계산 중 오류 발생"),
+    RCSCORE_RECALCULATING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "MATCHSCORE500", "rc 점수 재계산 중 오류 발생"),
+
     //추천리스트 조회
     RECOMMEND_LIST_NOT_FOUND(HttpStatus.NOT_FOUND,"SCORE001","추천리스트가 존재하지 않습니다."),
     MATCH_SCORE_NOT_FOUND(HttpStatus.NOT_FOUND,"SCORE002" ,"점수리스트가 존재하지 않습니다." );
-
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/springserver/global/cache/RedisCacheHelper.java
+++ b/src/main/java/com/example/springserver/global/cache/RedisCacheHelper.java
@@ -1,0 +1,70 @@
+package com.example.springserver.global.cache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class RedisCacheHelper {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // 저장
+    public void saveValue(String key, Object value, Duration ttl) {
+        redisTemplate.opsForValue().set(key, value, ttl);
+    }
+
+    // 조회
+    public <T> T getValue(String key, Class<T> type) {
+        Object value = redisTemplate.opsForValue().get(key);
+        return type.cast(value); // 안전한 타입 반환
+    }
+
+    // 삭제
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
+    // Set 추가
+    public void addToSet(String key, String value) {
+        redisTemplate.opsForSet().add(key, value);
+    }
+
+    public <T> Optional<T> get(String key, Class<T> clazz) {
+        Object value = redisTemplate.opsForValue().get(key);
+        if (value == null) return Optional.empty();
+
+        try {
+            return Optional.of(clazz.cast(value));
+        } catch (ClassCastException e) {
+            return Optional.empty();
+        }
+    }
+
+    // Set 조회
+    public Set<String> getSet(String key) {
+        Set<Object> rawSet = redisTemplate.opsForSet().members(key);
+        if (rawSet == null) return Collections.emptySet();
+
+        return rawSet.stream()
+                .map(Object::toString)
+                .collect(Collectors.toSet());
+    }
+
+    // Set 요소 제거
+    public void removeFromSet(String key, String value) {
+        redisTemplate.opsForSet().remove(key, value);
+    }
+
+    // Set 전체 삭제
+    public void deleteSet(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/example/springserver/global/cache/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/springserver/global/cache/config/RedisCacheConfig.java
@@ -25,7 +25,7 @@ import static org.springframework.data.redis.serializer.RedisSerializationContex
 
 @Configuration
 @EnableCaching
-public class CacheConfig {
+public class RedisCacheConfig {
     private ObjectMapper objectMapper() {
         PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
                 .allowIfSubType(Object.class)

--- a/src/main/java/com/example/springserver/repository/location/LocationRepository.java
+++ b/src/main/java/com/example/springserver/repository/location/LocationRepository.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 
 public interface LocationRepository extends JpaRepository<Location,Long> {
     Optional<Location> findByLocationId(Long locationId);
+    List<Location> findAllById(Iterable<Long> ids);
     List<Location> findAllBySigunguId(Long sigunguId);
 }

--- a/src/main/java/com/example/springserver/service/location/LocationService.java
+++ b/src/main/java/com/example/springserver/service/location/LocationService.java
@@ -24,6 +24,13 @@ public class LocationService {
         return locationRepository.findAllBySigunguId(sigunguId);
     }
 
+    public List<Location> findAllById(List<Long> locationIdList) {
+        if (locationIdList == null || locationIdList.isEmpty()) {
+            throw new GlobalException(ErrorCode.BAD_REQUEST);
+        }
+        return locationRepository.findAllById(locationIdList);
+    }
+
     public String getLocation(Long locationId){
         if(locationId == 0)
             throw new GlobalException(ErrorCode.BAD_REQUEST);

--- a/src/main/java/com/example/springserver/service/score/scheduler/ScoreCalculateScheduler.java
+++ b/src/main/java/com/example/springserver/service/score/scheduler/ScoreCalculateScheduler.java
@@ -2,9 +2,11 @@ package com.example.springserver.service.score.scheduler;
 
 import com.example.springserver.service.score.service.ScoreCalculationService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ScoreCalculateScheduler {
@@ -16,10 +18,10 @@ public class ScoreCalculateScheduler {
      */
     @Scheduled(cron = "0 0 4 * * ?")
     public void calculateDailyScores() {
-        System.out.println("[스케줄러 실행] 매일 새벽 4시, 전체 점수 업데이트 시작...");
+        log.info("[스케줄러 실행] 매일 새벽 4시, 전체 점수 업데이트 시작...");
 
         scoreCalculationService.summarize();
 
-        System.out.println("[스케줄러 실행] 전체 점수 업데이트 완료!");
+        log.info("[스케줄러 실행] 전체 점수 업데이트 완료!");
     }
 }

--- a/src/main/java/com/example/springserver/service/score/scheduler/ScoreRecalculateEventListener.java
+++ b/src/main/java/com/example/springserver/service/score/scheduler/ScoreRecalculateEventListener.java
@@ -1,19 +1,23 @@
 package com.example.springserver.service.score.scheduler;
 
+import com.example.springserver.domain.caregiver.repository.JobConditionRepository;
 import com.example.springserver.service.event.JobConditionChangedEvent;
 import com.example.springserver.service.event.RecruitConditionChangedEvent;
 import com.example.springserver.service.score.service.ScoreCalculationService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ScoreRecalculateEventListener {
 
     private final ApplicationContext applicationContext;
+    private final JobConditionRepository jobConditionRepository;
 
     /**
      * RC 변경된 Event 감지
@@ -22,14 +26,12 @@ public class ScoreRecalculateEventListener {
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleRecruitConditionChanged(RecruitConditionChangedEvent event) {
-        System.out.println("[이벤트 감지] RecruitCondition 변경됨. 점수 업데이트 실행.");
+        log.info("[이벤트 감지] RecruitCondition 변경됨. 점수 업데이트 실행.");
 
         // 추가 및 변경된 RecruitCondition ID를 기준으로 점수 업데이트
         applicationContext.getBean(ScoreCalculationService.class)
                 .recalculateScoresForRecruitWithNewTransaction(event.getRecruitConditionId());
     }
-
-
 
     /**
      * JC 변경된 Event 감지
@@ -38,7 +40,15 @@ public class ScoreRecalculateEventListener {
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleJobConditionChanged(JobConditionChangedEvent event) {
-        System.out.println("[이벤트 감지] JobCondition 변경됨. 점수 업데이트 실행.");
+        log.info("[이벤트 감지] JobCondition 변경됨. 점수 업데이트 실행.");
+
+        Long jobConditionId = event.getJobConditionId();
+
+        if (!jobConditionRepository.existsById(jobConditionId)) {
+            log.warn("[JobCondition Event] 존재하지 않는 jobConditionId({})로 점수 계산을 시도했으나 무시합니다.", jobConditionId);
+            return;
+        }
+
         applicationContext.getBean(ScoreCalculationService.class)
                 .recalculateScoresForJobWithNewTransaction(event.getJobConditionId());
     }

--- a/src/main/java/com/example/springserver/service/score/service/ScoreCalculationService.java
+++ b/src/main/java/com/example/springserver/service/score/service/ScoreCalculationService.java
@@ -3,7 +3,8 @@ package com.example.springserver.service.score.service;
 import com.example.springserver.domain.caregiver.entity.JobCondition;
 import com.example.springserver.domain.caregiver.entity.enums.ScheduleAvailability;
 import com.example.springserver.domain.caregiver.repository.JobConditionRepository;
-import com.example.springserver.domain.center.entity.*;
+import com.example.springserver.domain.center.entity.RecruitCondition;
+import com.example.springserver.domain.center.entity.RecruitTime;
 import com.example.springserver.domain.center.entity.enums.Week;
 import com.example.springserver.domain.center.repository.MatchRepository;
 import com.example.springserver.domain.center.repository.RecruitConditionRepository;
@@ -14,6 +15,7 @@ import com.example.springserver.domain.score.repository.ScoreRepository;
 import com.example.springserver.global.apiPayload.format.ErrorCode;
 import com.example.springserver.global.apiPayload.format.GlobalException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +26,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ScoreCalculationService {
@@ -40,7 +43,12 @@ public class ScoreCalculationService {
      */
     @Transactional
     public void summarize() {
-        scoreRepository.deleteAllMarkedAsDeleted();
+        try {
+            scoreRepository.deleteAllMarkedAsDeleted();
+        } catch (Exception e) {
+            log.error("scoreRepository.deleteAllMarkedAsDeleted 실패", e);
+            throw new GlobalException(ErrorCode.INTERNAL_SERVER_ERROR_DELETE_MATCH_SCORE);
+        }
     }
 
     /**
@@ -49,7 +57,6 @@ public class ScoreCalculationService {
      *  존재하지 않으면 새로 생성합니다.
      */
     //rc 변경시 update
-    @Transactional
     public void recalculateScoresForRecruit(Long recruitConditionId) {
         RecruitCondition rc = fetchRecruitCondition(recruitConditionId);
         Map<Week, Long> rcDayTimeMap = buildRcDayTimeMap(rc);
@@ -71,50 +78,59 @@ public class ScoreCalculationService {
      * JC 변경 시 점수 재계산을 수행합니다.
      * 존재하는 MatchScore는 수정/복구하고, 존재하지 않으면 새로 생성하여 저장합니다.
      */
-    @Transactional
     public void recalculateScoresForJob(Long jobConditionId) {
-        JobCondition jc = fetchJobCondition(jobConditionId);
-        List<RecruitCondition> rcList = fetchRelatedRecruitConditions(jc);
-        Map<String, MatchScore> existingScoreMap = fetchExistingMatchScoreMap(jobConditionId);
+        try {
+            JobCondition jc = fetchJobCondition(jobConditionId);
+            List<RecruitCondition> rcList = fetchRelatedRecruitConditions(jc);
+            Map<String, MatchScore> existingScoreMap = fetchExistingMatchScoreMap(jobConditionId);
 
-        List<MatchScore> results = new ArrayList<>();
+            List<MatchScore> results = new ArrayList<>();
 
-        for (RecruitCondition rc : rcList) {
-            Map<Week, Long> rcDayTimeMap = buildRcDayTimeMap(rc.getRecruitTimes());
+            for (RecruitCondition rc : rcList) {
+                Map<Week, Long> rcDayTimeMap = buildRcDayTimeMap(rc.getRecruitTimes());
 
-            if (!isAvailableOnSameDay(jc, rcDayTimeMap)) continue;
+                if (!isAvailableOnSameDay(jc, rcDayTimeMap)) continue;
 
-            int conditionScore = calculateConditionScore(jc, rc);
-            int timeScore = calculateTimeScore(rcDayTimeMap, jc);
-            int finalScore = (conditionScore + timeScore) / 2;
+                int conditionScore = calculateConditionScore(jc, rc);
+                int timeScore = calculateTimeScore(rcDayTimeMap, jc);
+                int finalScore = (conditionScore + timeScore) / 2;
 
-            MatchStatus match = matchRepository.findByJobCondition_IdAndRecruitCondition_Id(
-                    rc.getRecruitConditionId(), jc.getId());
+                MatchStatus match = matchRepository.findByJobCondition_IdAndRecruitCondition_Id(
+                        rc.getRecruitConditionId(), jc.getId());
 
-            String key = generateKey(jc.getId(), rc.getRecruitConditionId());
+                String key = generateKey(jc.getId(), rc.getRecruitConditionId());
 
-            if (existingScoreMap.containsKey(key)) {
-                MatchScore updated = updateExistingScore(existingScoreMap.get(key), match, finalScore);
-                results.add(updated);
-            } else {
-                MatchScore created = createNewScore(jc, rc, finalScore, match);
-                results.add(created);
+                if (existingScoreMap.containsKey(key)) {
+                    MatchScore updated = updateExistingScore(existingScoreMap.get(key), match, finalScore);
+                    results.add(updated);
+                } else {
+                    MatchScore created = createNewScore(jc, rc, finalScore, match);
+                    results.add(created);
+                }
             }
+
+            Set<String> processedKeys = results.stream()
+                    .map(ms -> generateKey(ms.getJobCondition().getId(), ms.getRecruitCondition().getRecruitConditionId()))
+                    .collect(Collectors.toSet());
+
+            List<MatchScore> toSoftDelete = existingScoreMap.entrySet().stream()
+                    .filter(entry -> !processedKeys.contains(entry.getKey()))
+                    .map(Map.Entry::getValue)
+                    .filter(ms -> ms.getDeletedAt() == null)
+                    .map(ms -> {
+                        ms.setDeletedAt(LocalDateTime.now());
+                        return ms;
+                    })
+                    .toList();
+
+            results.addAll(toSoftDelete);
+            scoreRepository.saveAll(results);
+        } catch (Exception e) {
+            log.error("recalculateScoresForJob 실패: jobConditionId = {}", jobConditionId, e);
+            throw new GlobalException(ErrorCode.JCSCORE_RECALCULATING_FAIL);
         }
-        Set<String> processedKeys = results.stream()
-                .map(ms -> generateKey(ms.getJobCondition().getId(), ms.getRecruitCondition().getRecruitConditionId()))
-                .collect(Collectors.toSet());
-
-        List<MatchScore> toSoftDelete = existingScoreMap.entrySet().stream()
-                .filter(entry -> !processedKeys.contains(entry.getKey()))
-                .map(Map.Entry::getValue)
-                .filter(ms -> ms.getDeletedAt() == null) // 이미 삭제된 건 제외
-                .peek(ms -> ms.setDeletedAt(LocalDateTime.now()))
-                .toList();
-
-        results.addAll(toSoftDelete);
-        scoreRepository.saveAll(results);
     }
+
     /**
      * 주어진 ID로 RecruitCondition을 조회합니다.
      * 존재하지 않으면 예외를 발생시킵니다.
@@ -227,7 +243,6 @@ public class ScoreCalculationService {
                 results.add(newScore);
             }
         }
-
         return results;
     }
 
@@ -247,7 +262,10 @@ public class ScoreCalculationService {
                 .filter(entry -> !processedKeys.contains(entry.getKey()))
                 .map(Map.Entry::getValue)
                 .filter(ms -> ms.getDeletedAt() == null)
-                .peek(ms -> ms.setDeletedAt(LocalDateTime.now()))
+                .map(ms -> {
+                    ms.setDeletedAt(LocalDateTime.now());
+                    return ms;
+                })
                 .toList();
     }
 
@@ -256,6 +274,7 @@ public class ScoreCalculationService {
      * 존재하지 않으면 예외를 발생시킵니다.
      */
     private JobCondition fetchJobCondition(Long jobConditionId) {
+        log.info("jobConditionId = {}", jobConditionId);
         return jobConditionRepository.findById(jobConditionId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.JOB_CONDITION_NOT_FOUND));
     }
@@ -265,7 +284,7 @@ public class ScoreCalculationService {
      */
     private List<RecruitCondition> fetchRelatedRecruitConditions(JobCondition jc) {
         List<Long> locationIds = jc.getWorkLocations().stream()
-                .map(wl -> wl.getLocationId().getLocationId())
+                .map(wl -> wl.getLocation().getLocationId())
                 .toList();
         return recruitConditionRepository.findAllByRecruitLocation_LocationIdIn(locationIds);
     }
@@ -334,23 +353,22 @@ public class ScoreCalculationService {
         return jobConditionId + "_" + recruitConditionId;
     }
 
-
-    /**
-     * 여기를 @Transactional로 나눴더니 Update/Delete Transactional 안씌워지는 오류 해결되더라구요
-     * 여기 통해서 점수계산 Transactional 씌워서 들어가게되요
-     */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void recalculateScoresForJobWithNewTransaction(Long id) {
-        recalculateScoresForJob(id);
-    }
-
-    /**
-     * 여기를 @Transactional로 나눴더니 Update/Delete Transactional 안씌워지는 오류 해결되더라구요
-     * 여기 통해서 점수계산 Transactional 씌워서 들어가게되요
-     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void recalculateScoresForRecruitWithNewTransaction(Long recruitConditionId) {
-        recalculateScoresForRecruit(recruitConditionId);
+        try {
+            recalculateScoresForRecruit(recruitConditionId);
+        } catch (Exception e) {
+            throw new GlobalException(ErrorCode.RCSCORE_RECALCULATING_FAIL);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recalculateScoresForJobWithNewTransaction(Long jobConditionId) {
+        try {
+            recalculateScoresForJob(jobConditionId);
+        } catch (Exception e) {
+            throw new GlobalException(ErrorCode.JCSCORE_RECALCULATING_FAIL);
+        }
     }
 
     private int calculateConditionScore(JobCondition jc, RecruitCondition rc) {


### PR DESCRIPTION
# 💡 Issue
- #122 

# 🌱 Key changes
- [x] 조회 빈도가 높은 Location의 일부 필드 캐싱처리 (c9d61840653cae91f5f70d3d69b6d5df7112ac35)
- [x] 구직조건의 근무 가능지역 캐싱에 적용 (f61437aa3e31ff55596674810ba91c634b294799)
- [x] 불필요한 어노테이션 제거 & 로직 개선
   - [x] 캐싱을 위한 공통 로직은 RedisCacheHandler 클래스에서 관리하도록 수정 (707246833d68fc90dc816fb6a49b27e1d096572e)
- [x] 버그 수정 (c74b7c727a6e9f61de619c640b1ae0e6b42dbe7e)

# ✅ To Reviewers
리팩토링하면서 알게된 
구직조건 필드 중 근무 가능 지역을 수정하는 경우에 구직조건 데이터가 아예 삭제되는 버그가 있어서 같이 해결했습니다. 

# 📸 스크린샷
