### PR TITLE
refactor: SortedSet을 활용한 매칭 점수 정렬 캐싱 - #125

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 .env
+src/test/resources/.env.test.properties
+
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/example/springserver/MockDataGenerator.java
+++ b/src/main/java/com/example/springserver/MockDataGenerator.java
@@ -30,9 +30,9 @@ public class MockDataGenerator implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) throws Exception {
-    //        System.out.println("Mock 데이터 생성 메서드 실행...");
-    //        createMockData();
-    //        System.out.println("Mock 데이터 생성 메서드 끝...");
+        //        System.out.println("Mock 데이터 생성 메서드 실행...");
+        //        createMockData();
+        //        System.out.println("Mock 데이터 생성 메서드 끝...");
     }
 
     /* 애플리케이션 실행 시점에 Mock 데이터 생성 */
@@ -62,44 +62,44 @@ public class MockDataGenerator implements ApplicationRunner {
     @Autowired
     CareRepository careRepository;
 
-    void createMockData() {
+    public void createMockData() {
         for (int i = 0; i < 10; i++) {
             admin();
         }
         for (int i = 0; i < 10; i++) {
-            elder();
+            Elder elder = elder();
+
+            for (int j = 0; j < 1; j++) {
+                recruitCondition(Math.toIntExact(elder.getElderId()));
+                care(Math.toIntExact(elder.getElderId()));
+                recruitTime();
+                recruitLocation();
+            }
+
         }
 
         // 3. 요양보호사 데이터 생성
         for (int i = 0; i < 10; i++) {
-            careGiver();
-        }
-
-        // 4. 자격증 및 경력 데이터 생성
-        for (int i = 0; i < 5; i++) {
-            certificate();
-            experience();
-        }
-
-        // 5. 구직 조건, 근무지 데이터 생성
-        for (int i = 0; i < 1; i++) {
-            jobCondition(i+1);
+            Caregiver caregiver = careGiver();
+            for (int j = 0; j < 3; j++) {
+                certificate();
+                experience();
+            }
+            jobCondition(Math.toIntExact(caregiver.getId()));
             workLocation();
         }
 
-        // 6. 구인 조건과 시간 데이터 생성
-        for (int i = 0; i < 1; i++) {
-            recruitCondition(i+1);
-            care(i+1);
-        }
-        for (int i = 0; i < 1; i++) {
-            recruitTime();
-            recruitLocation();
-        }
+
+
     }
 
     void certificate() {
-        Caregiver caregiver = caregiverRepository.findRandom().get();
+        Optional<Caregiver> caregiverOptional = caregiverRepository.findRandom();
+        if (!caregiverOptional.isPresent()) {
+            System.out.println("Caregiver not found");
+            return; // 또는 다른 처리
+        }
+        Caregiver caregiver = caregiverOptional.get();
         String certNum = faker.text().text();
         CertType certType = faker.options().option(CertType.class);
         Level certRate = faker.options().option(Level.class);
@@ -109,7 +109,12 @@ public class MockDataGenerator implements ApplicationRunner {
     }
 
     void experience() {
-        Caregiver caregiver = caregiverRepository.findRandom().get();
+        Optional<Caregiver> caregiverOptional = caregiverRepository.findRandom();
+        if (!caregiverOptional.isPresent()) {
+            System.out.println("Caregiver not found");
+            return; // 또는 다른 처리
+        }
+        Caregiver caregiver = caregiverOptional.get();
         Integer duration = faker.number().numberBetween(1, 10);
         String title = faker.text().text();
         String description = faker.text().text();
@@ -130,7 +135,7 @@ public class MockDataGenerator implements ApplicationRunner {
         adminRepository.save(admin);
     }
 
-    void elder() {
+    Elder elder() {
         Center center = centerRepository.findRandom().get(); // 센터: 1~5
         String name = faker.name().fullName();
         Integer gender = faker.number().numberBetween(0, 1); // 1 or 0
@@ -152,12 +157,12 @@ public class MockDataGenerator implements ApplicationRunner {
         Elder elder = new Elder(center, name, gender, birth, rate, inmateTypes, null, weight,
                 isTemporarySave, isNormal, hasShortTermMemoryLoss, wandersOutside, actsLikeChild,
                 hasDelusions, hasAggressiveBehavior);
-        elderRepository.save(elder);
+        return elderRepository.save(elder);
     }
 
     void recruitCondition(int i) {
         Elder elder = elderRepository.findById(Long.valueOf(i))
-                .orElseThrow(() -> new RuntimeException("===== elder 중복 ====="));
+                .orElseThrow(() -> new RuntimeException("elderId ==== " + i));
 
         List<CareType> careTypes = Collections.singletonList(faker.options().option(CareType.class));
 
@@ -270,14 +275,13 @@ public class MockDataGenerator implements ApplicationRunner {
         recruitTimeRepository.save(recruitTime);
     }
 
-    void careGiver() {
+    Caregiver careGiver() {
         String username = faker.funnyName().name();
         String password = faker.hashing().sha256();
         String name = faker.name().fullName();
         String contact = String.valueOf(faker.phoneNumber());
         Boolean car = faker.bool().bool();
         Boolean education = faker.bool().bool();
-//        String img = faker.image().base64JPG();
         String intro = faker.text().text();
         String address = String.valueOf(faker.address());
         Boolean employmentStatus = faker.bool().bool();
@@ -285,11 +289,23 @@ public class MockDataGenerator implements ApplicationRunner {
         List<Certificate> certificates = certificateRepository.findRandom().stream().toList();
 
         Caregiver caregiver = new Caregiver(username, password, name, contact, car, education, null, intro, address, employmentStatus, experiences, certificates);
-        Caregiver savedCaregiver = caregiverRepository.save(caregiver);
-        System.out.println("Saved Caregiver ID: " + savedCaregiver.getId());
+
+        // Log before saving
+        System.out.println("Saving caregiver: " + caregiver);
+
+        return caregiverRepository.save(caregiver);
     }
 
-    void jobCondition(int i) {
+    // 수정된 코드 (방법1 적용)
+    public void jobCondition(int caregiverId) {
+        Optional<Caregiver> optionalCaregiver = caregiverRepository.findById((long) caregiverId);
+        if (optionalCaregiver.isEmpty()) {
+            System.out.println("caregiverId " + caregiverId + "에 해당하는 Caregiver가 존재하지 않아 jobCondition 생성 생략");
+            return; // 예외 던지지 않고 그냥 넘어감
+        }
+
+        Caregiver caregiver = optionalCaregiver.get();
+
         ScheduleAvailability flexibleSchedule = faker.options().option(ScheduleAvailability.class);
         Integer desiredHourlyWage = faker.number().numberBetween(10030, 50000);
         ScheduleAvailability selfFeeding = faker.options().option(ScheduleAvailability.class);
@@ -314,25 +330,15 @@ public class MockDataGenerator implements ApplicationRunner {
         Integer dayOfWeek = faker.number().numberBetween(1, 6);
         Long startTime = (long) faker.number().numberBetween(18, 28);
         Long endTime = (long) faker.number().numberBetween(30, 36);
-        Caregiver caregiver = caregiverRepository.findById((long)i)
-                .orElseThrow(() -> new RuntimeException("=========== caregiver 매핑 안됨 ==========="));
 
         JobCondition jobCondition = new JobCondition(flexibleSchedule, desiredHourlyWage, selfFeeding, mealPreparation,
                 cookingAssistance, enteralNutritionSupport, selfToileting, occasionalToiletingAssist, diaperCare, catheterOrStomaCare,
                 independentMobility, mobilityAssist, wheelchairAssist, immobile, cleaningLaundryAssist, bathingAssist, hospitalAccompaniment,
                 exerciseSupport, emotionalSupport, cognitiveStimulation, dayOfWeek, startTime, endTime, caregiver);
 
-        // 근무 가능 지역 랜덤 2개 생성
-        for(int k=0; k<2; k++) {
-            WorkLocation workLocation = new WorkLocation(
-                    jobCondition, locationRepository.findByLocationId((long) faker.number().numberBetween(1, 10))
-                    .orElseThrow(() -> new RuntimeException("=== locatino error ====="))
-            );
-            // recruitCondition에 추가
-            jobCondition.addWokLocation(workLocation);
-        }
         jobConditionRepository.save(jobCondition);
     }
+
 
     void workLocation() {
         Location locationId = locationRepository.findByLocationId((long) faker.number().numberBetween(1, 10))

--- a/src/main/java/com/example/springserver/domain/center/entity/RecruitCondition.java
+++ b/src/main/java/com/example/springserver/domain/center/entity/RecruitCondition.java
@@ -133,9 +133,12 @@ public class RecruitCondition extends BaseEntity {
     }
 
     public void addRecruitTime(RecruitTime recruitTime) {
+        if (this.recruitTimes == null) {
+            this.recruitTimes = new ArrayList<>();
+        }
         if (!this.recruitTimes.contains(recruitTime)) {
             this.recruitTimes.add(recruitTime);
-            recruitTime.setRecruitCondition(this); // 양방향 관계 설정
+            recruitTime.setRecruitCondition(this);
         }
     }
 

--- a/src/main/java/com/example/springserver/domain/score/cache/MatchScoreCacheRepository.java
+++ b/src/main/java/com/example/springserver/domain/score/cache/MatchScoreCacheRepository.java
@@ -1,55 +1,72 @@
 package com.example.springserver.domain.score.cache;
 
+import com.example.springserver.global.apiPayload.format.ErrorCode;
+import com.example.springserver.global.apiPayload.format.GlobalException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
+import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
 public class MatchScoreCacheRepository {
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private static final String KEY_PREFIX = "match_score:";
 
-    public List<MatchScoreCache> findByRecruitConditionId(Long recruitConditionId) {
-        String pattern = KEY_PREFIX + recruitConditionId + ":";
-        Cursor<byte[]> cursor = redisTemplate.execute((RedisCallback<Cursor<byte[]>>) connection ->
-                connection.scan(ScanOptions.scanOptions().match(pattern + "*").build()));
+    public String getKeyByRecruitConditionId(Long id) {return KEY_PREFIX + id;}
 
-        List<MatchScoreCache> result = new ArrayList<>();
-        while (cursor != null && cursor.hasNext()) {
-            byte[] key = cursor.next();
-            Object cache = redisTemplate.opsForValue().get(new String(key));
-            if (cache != null) {
-                result.add((MatchScoreCache) cache);
-            }
-        }
-        return result;
+    public List<MatchScoreCache> findTopByRecruitConditionId(Long recruitConditionId) {
+        String key = getKeyByRecruitConditionId(recruitConditionId);
+        Set<Object> results = redisTemplate.opsForZSet().reverseRange(key, 0, -1);
+
+        if (results == null) return List.of();
+
+        return results.stream()
+                .map(this::deserialize)
+                .toList();
     }
 
     public void saveAll(List<MatchScoreCache> caches) {
-        // Redis 파이프라인 처리
         redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
             for (MatchScoreCache cache : caches) {
-                String key = KEY_PREFIX + cache.getRecruitConditionId() + ":" + cache.getId();
-                connection.set(key.getBytes(), serialize(cache));
+                String key = getKeyByRecruitConditionId(cache.getRecruitConditionId());
+                String value = serialize(cache);
+                double score = cache.getScore();
+
+                redisTemplate.opsForZSet().add(key, value, score);
+                redisTemplate.expire(key, Duration.ofMinutes(60)); // 임시 1시간 설정
             }
             return null;
         });
     }
 
-    private byte[] serialize(MatchScoreCache cache) {
+    // 직렬화
+    private String serialize(MatchScoreCache cache) {
         try {
-            return new ObjectMapper().writeValueAsBytes(cache);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to serialize cache", e);
+            return objectMapper.writeValueAsString(cache);
+        } catch (JsonProcessingException e) {
+            throw new GlobalException(ErrorCode.MATCH_SCORE_SERIALIZE_FAILED);
+        }
+    }
+
+    // 역직렬화
+    private MatchScoreCache deserialize(Object value) {
+        if (value instanceof String stringValue) {
+            try {
+                return objectMapper.readValue(stringValue, MatchScoreCache.class);
+            } catch (JsonProcessingException e) {
+                throw new GlobalException(ErrorCode.MATCH_SCORE_DESERIALIZE_FAILED);
+            }
+        } else {
+            throw new GlobalException(ErrorCode.MATCH_SCORE_DESERIALIZE_FAILED);
         }
     }
 }

--- a/src/main/java/com/example/springserver/domain/score/service/ScoreService.java
+++ b/src/main/java/com/example/springserver/domain/score/service/ScoreService.java
@@ -32,7 +32,7 @@ public class ScoreService {
 
         // Cache hit
         if (!cachedScores.isEmpty()) {
-
+            log.info("[Redis] score 조회 ========");
             List<MatchScore> scores = cachedScores.stream()
                     .map(matchScoreCacheConverter::fromCache)
                     .toList();
@@ -40,6 +40,7 @@ public class ScoreService {
         }
 
         // Cache miss → DB 조회
+        log.info("[MySQL] score 조회 ========");
         List<MatchScore> scores = scoreRepository.findByRecruitConditionId(recruitConditionId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.RECOMMEND_LIST_NOT_FOUND));
 

--- a/src/main/java/com/example/springserver/domain/score/service/cache/MatchScoreCacheService.java
+++ b/src/main/java/com/example/springserver/domain/score/service/cache/MatchScoreCacheService.java
@@ -16,7 +16,7 @@ public class MatchScoreCacheService {
     private final MatchScoreCacheRepository cacheRepository;
 
     public List<MatchScoreCache> getByRecruitConditionId(Long recruitConditionId) {
-        return cacheRepository.findByRecruitConditionId(recruitConditionId);
+        return cacheRepository.findTopByRecruitConditionId(recruitConditionId);
     }
 
     public void saveAll(List<MatchScoreCache> caches) {

--- a/src/main/java/com/example/springserver/global/apiPayload/format/ErrorCode.java
+++ b/src/main/java/com/example/springserver/global/apiPayload/format/ErrorCode.java
@@ -94,6 +94,10 @@ public enum ErrorCode {
     JCSCORE_RECALCULATING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "MATCHSCORE500", "jc 점수 재계산 중 오류 발생"),
     RCSCORE_RECALCULATING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "MATCHSCORE500", "rc 점수 재계산 중 오류 발생"),
 
+    // 매칭 점수 캐싱 에러
+    MATCH_SCORE_SERIALIZE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MATCHSCORE500", "매칭 점수 Redis 직렬화 오류 발생"),
+    MATCH_SCORE_DESERIALIZE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MATCHSCORE500", "매칭 점수 Redis 역직렬화 오류 발생"),
+
     //추천리스트 조회
     RECOMMEND_LIST_NOT_FOUND(HttpStatus.NOT_FOUND,"SCORE001","추천리스트가 존재하지 않습니다."),
     MATCH_SCORE_NOT_FOUND(HttpStatus.NOT_FOUND,"SCORE002" ,"점수리스트가 존재하지 않습니다." );

--- a/src/main/java/com/example/springserver/service/score/service/ScoreCalculationService.java
+++ b/src/main/java/com/example/springserver/service/score/service/ScoreCalculationService.java
@@ -10,8 +10,11 @@ import com.example.springserver.domain.center.repository.MatchRepository;
 import com.example.springserver.domain.center.repository.RecruitConditionRepository;
 import com.example.springserver.domain.match.entity.Match;
 import com.example.springserver.domain.match.entity.enums.MatchStatus;
+import com.example.springserver.domain.score.cache.MatchScoreCache;
+import com.example.springserver.domain.score.cache.MatchScoreCacheConverter;
 import com.example.springserver.domain.score.entity.MatchScore;
 import com.example.springserver.domain.score.repository.ScoreRepository;
+import com.example.springserver.domain.score.service.cache.MatchScoreCacheService;
 import com.example.springserver.global.apiPayload.format.ErrorCode;
 import com.example.springserver.global.apiPayload.format.GlobalException;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +38,8 @@ public class ScoreCalculationService {
     private final RecruitConditionRepository recruitConditionRepository;
     private final MatchRepository matchRepository;
     private final ScoreRepository scoreRepository;
+    private final MatchScoreCacheService matchScoreCacheService;
+    private final MatchScoreCacheConverter matchScoreCacheConverter;
 
     // 주기적 삭제
     /**
@@ -56,8 +61,9 @@ public class ScoreCalculationService {
      *  기존 MatchScore가 존재하면 복구 및 업데이트,
      *  존재하지 않으면 새로 생성합니다.
      */
-    //rc 변경시 update
+    //rc 변경시 update (Redis, DB 수정 O)
     public void recalculateScoresForRecruit(Long recruitConditionId) {
+        log.info("recalculateScoresForRecruit===========");
         RecruitCondition rc = fetchRecruitCondition(recruitConditionId);
         Map<Week, Long> rcDayTimeMap = buildRcDayTimeMap(rc);
         int rcDayMask = calculateRcDayMask(rcDayTimeMap);
@@ -70,15 +76,23 @@ public class ScoreCalculationService {
         List<MatchScore> toSoftDelete = filterSoftDeleteTargetsForRecruit(existingScoreMap, results);
 
         results.addAll(toSoftDelete);
+
+        // DB data -> cache로 변환 & 저장
+        List<MatchScoreCache> newCaches = results.stream()
+                .map(matchScoreCacheConverter::toCache)
+                .toList();
+
         scoreRepository.saveAll(results);
+        matchScoreCacheService.saveAll(newCaches);
     }
 
-    // JC 변경시 Update
+    // JC 변경시 Update (Redis, DB 수정 O)
     /**
      * JC 변경 시 점수 재계산을 수행합니다.
      * 존재하는 MatchScore는 수정/복구하고, 존재하지 않으면 새로 생성하여 저장합니다.
      */
     public void recalculateScoresForJob(Long jobConditionId) {
+        log.info("recalculateScoresForJob===========");
         try {
             JobCondition jc = fetchJobCondition(jobConditionId);
             List<RecruitCondition> rcList = fetchRelatedRecruitConditions(jc);
@@ -124,7 +138,14 @@ public class ScoreCalculationService {
                     .toList();
 
             results.addAll(toSoftDelete);
+
+            // DB data -> cache로 변환 & 저장
+            List<MatchScoreCache> newCaches = results.stream()
+                    .map(matchScoreCacheConverter::toCache)
+                    .toList();
+
             scoreRepository.saveAll(results);
+            matchScoreCacheService.saveAll(newCaches);
         } catch (Exception e) {
             log.error("recalculateScoresForJob 실패: jobConditionId = {}", jobConditionId, e);
             throw new GlobalException(ErrorCode.JCSCORE_RECALCULATING_FAIL);

--- a/src/test/java/com/example/springserver/application/ScoreCalculationServiceTest.java
+++ b/src/test/java/com/example/springserver/application/ScoreCalculationServiceTest.java
@@ -1,0 +1,88 @@
+package com.example.springserver.application;
+
+import com.example.springserver.MockDataGenerator;
+import com.example.springserver.domain.caregiver.repository.JobConditionRepository;
+import com.example.springserver.domain.center.entity.RecruitCondition;
+import com.example.springserver.domain.center.repository.RecruitConditionRepository;
+import com.example.springserver.domain.score.entity.MatchScore;
+import com.example.springserver.domain.score.repository.ScoreRepository;
+import com.example.springserver.service.score.service.ScoreCalculationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@TestPropertySource("classpath:.env.test.properties")
+@SpringBootTest
+class ScoreCalculationServiceTest {
+
+    @Autowired
+    private MockDataGenerator mockDataGenerator;
+
+    @Autowired
+    private JobConditionRepository jobConditionRepository;
+
+    @Autowired
+    private RecruitConditionRepository recruitConditionRepository;
+
+    @Autowired
+    private ScoreCalculationService scoreCalculationService;
+
+    @Autowired
+    private ScoreRepository scoreRepository;
+
+    @BeforeEach
+    void setUp() {
+        mockDataGenerator.createMockData(); // 목 데이터 생성
+    }
+
+    @Test
+    @Transactional
+    void testRecalculateScoresForRecruit() {
+        // given
+        RecruitCondition recruitCondition = recruitConditionRepository.findAll().get(0);
+        Long recruitConditionId = recruitCondition.getRecruitConditionId();
+
+        // when
+        scoreCalculationService.recalculateScoresForRecruit(recruitConditionId);
+
+        // then
+        List<MatchScore> scores = scoreRepository.findAllByRecruitConditionIncludingDeleted(recruitConditionId);
+
+        assertTrue(!scores.isEmpty(), "RecruitCondition에 대한 MatchScore 생성 성공");
+
+        for (MatchScore score : scores) {
+            assertEquals(recruitConditionId, score.getRecruitCondition().getRecruitConditionId());
+            assertNotNull(score.getScore());
+            assertNotNull(score.getJobCondition());
+        }
+    }
+
+//    @Test
+//    void testRecalculateScoresForJob() {
+//        // given
+//        JobCondition job = jobConditionRepository.findAll().get(0);
+//        Long jobConditionId = job.getId();
+//
+//        // when
+//        scoreCalculationService.recalculateScoresForJob(jobConditionId);
+//
+//        // then
+//        List<MatchScore> scores = scoreRepository.findAllByJobConditionIncludingDeleted(jobConditionId);
+//
+//        assertTrue(!scores.isEmpty(), "JobCondition에 대한 MatchScore 생성 성공");
+//        for (MatchScore score : scores) {
+//            assertEquals(jobConditionId, score.getJobCondition().getId());
+//            assertNotNull(score.getScore());
+//            assertNotNull(score.getRecruitCondition());
+//        }
+//    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,63 @@
+spring:
+  application:
+    name: test
+
+  config:
+    import: "classpath:.env.test.properties"
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${SPRING_DATASOURCE_HOST}:${SPRING_DATASOURCE_DB_PORT}/${SPRING_DATASOURCE_DB}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+
+  data:
+    redis:
+      host: ${SPRING_REDIS_HOST}
+      port: ${SPRING_REDIS_PORT}
+      password: ${SPRING_REDIS_PASSWORD}
+
+  cloud:
+    aws:
+      s3:
+        bucket: ${BUCKET_NAME}
+      credentials:
+        access-key: ${S3_ACCESS_KEY}
+        secret-key: ${S3_SECRET_KEY}
+      region:
+        static: ${S3_REGION}
+      cloudfront:
+        domain: ${CLOUDFRONT_DOMAIN}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+    defer-datasource-initialization: true # data.sql 실행을 테이블 생성이후로 지연https://petstore.swagger.io/v2/swagger.json
+
+  sql:
+    init:
+      mode: always
+
+      data-locations: classpath:/data.sql, classpath:/center.sql
+
+  jwt:
+    secret: ${JWT_SECRET}
+
+jasypt:
+  encryptor:
+    key: ${JYSPT_ENCRYPTOR_KEY}
+
+firebase:
+  type: ENC(nUf+AQLKIoVbrUXAPj6o8KmigffUAGfX)
+  project_id: ENC(woWrwlYWBpl9Gdw/vSyP60c/jFLp0sID)
+  private_key_id: ENC(qunsiUGDvEeLAf5rWXZ5J6icAgdyvViszHj1RldYLJKdgKQAzsbXZe4APcZIKf3h0wlqKLzDfpo=)
+  private_key: ENC(tYtl2QxUwwqNG5VT7AiM6q2Vdf9SARWfgXYJeycOKa1DlrAVVCatowfG5dBJJlolNkfKqbDjB+iliMeMYAjubvdPesl+G8tktJU7C44nBkYswc+LPz8D8ozF4aiOLcxkN58weckNPcZabkldIktDDkmX1UQf/qV4NUvhbrFzIu9IynyGoRRpFpIx184rFih8tpeb9C4R9byCxadhTfQiBPziN59XxbF59h7rSo07m4ld+wr9jSA5DzEVEGaEG5IwidyzuiQjKJxbYdW8q9+tj7iYggZWFER4gJR8mUs1xXZfSdYjCi042rUCJGK/GtGZimncueVFvlOOcjaNAGSzy4t1vLxkiAc6RfwNgnKBtAAntUDUphqhs4w6Q7b7Y+Gv1fSgXMijgrf+0Okem0E59J+qOC7zz7/KAWP47AMEKlt14USIUz4Tz9kgtmsMgJAkuaSCi3Q/TufMEjP6uoOZ71ssmEoznRKLFLG4uvR+OCKVAPOBYk2DUhO8OYXNbrI0gtgWFLl7Y3RYgwb3IUbmmLhc4v/ooy7GpCKV/Gb6ZNQb7hs+dkxmwLvpOru/lYB8DwmP49pXnIlTsvKaSvvdpODhB3AnKMW6zvctUSi/I1FihszJ1soBPMEoLY3zZxAW7b3w+o+MNgoeI4bmmfbmPc8LITbz8xKVBiL8/NnIp9CbEK9MojId4vczeroYKp7yUEVw30BnfmDAyRcHDo4gTOyJHWzdcl4mF84r9tF9HvLajCmnhCjkplu7Zn3kCAQkrfcnhe+cDLcuL8PzkahbrFlJQz75WDH5qe/w1PQVkUmTHXE11rah48ZgnFF7gfov/M6PGCRR+joVEOSkCFfAlmMylp+e6czFCSF6JKgHdlZFEU2qrCVcazhmWhVA75Tj7DfxS62jO74UEF8gluLWpl3N94i0pSBxumsBAIUrEdomJI4+c7wEn0blRglAt4SP3+oTy8OH+ct11A2felE2OFNIaAyzGyV344CeiD2KrgCwdzDYiKgEIta4Dog7UB3G6I+QQBUtPJXfc6XuJ2FtAFv/OnAvFGZBdQNpUETnq6Z+ozXPXy78Bf2C4CZEM99wrLHDpDtTZASUSQghhuUP1XGCdHgdrq1ow59OaFK51Nx7tUreN/P7Sva1iXkHaPZUmKmROST/lmWF8iqmnpGhdDYfYjV1vbglZ1g96bLUnOF4mOt3ut8k/yHmRyq7mHernPly04E1eX/iSsiFQLqovdbJSlAjC3cUoRY5EINXvWGRKiSQg/MZCrnFnC+sAPCHK27AGyUrouRVYOfWSTFtlfQ/0No5uKfwgIM83eoGHWSCYIOaoLM9n/DEW3zVT4EuJDDaR3Ag5PkD59oVHPaBrXv3rIA05voLP+p7lu8KbfPsIlEWy6ooFB15viYAgfZgLus3JNcc8YjtQCDdXzqBUx70qBHYP/rfvfntEqHoRqnjQ1jWTDEZmUjLtF+SgLPCpi/2FYAK04sfS35VzDb3bzGs06Wnp5wBypi218CIZxUX04rQoJROqVh5+GZsvU6OacYm9mlQM+KtSxFnGEeQvJTxh+a1lccl4pWo8KNost+JJ4NUTH2XymiTBMYXzeeck55kbf/eFBPE5naTWmNl/ldqoOTw2N7Q1+YYl0OVp9T17WWytd87nVeBG/oClcnNgJgK2FevcdY/YZZkj/4FehXcWY5Mr41XiRXUzKp3svLuUUTYdP31tLqnMQHo1Hf37BvhXbrjNj/+wr4fZyJcv8NdONNEGFeDFH2rYcqD6DXoWtbubgFzV9UOLXR/k5WbuD98Xu9SMxt2rppou5JmNMdMrCIFdqcIaSVjz0aX8Q4qMibMHT0JQgaXo0x8V5yXov3N1iwP8MIeFzq2jQXDYgLIrU1q1wOSmMiqRZcT1oqDkcwan5CuoMIPAH23Xhb5PbXi7OHJK7UfBrJiqyhwnSxZ9gWQJl/GeHJBIR/entEtAzRyV66t9aTokM4qUp5KzEW+3cxOaH9hvhjX4MQ5qxIfHyc+3do6A41Nfxo004pQLik7vheFzKgURYCRa7rbP1bXwfbZEu6iSNMAGjAbjlLVFeU3Sn8uaozi3E43Jg3KRWQEfwM7A+hCqw7nbJ0NOzmcHystmrUqKcjsw12c9d5SxPWDs+fvvA4IpIWO8OFFI53FFeHcfeG3BrfDigASkQdZXOGu+dn+7P0fbZQlPNqn8X1sfIea7DD5/+sA4PwIlzt0jrMmq81YFi97Q1epI5nhXpmHjD4BQnRcYpH+Wc+tAqY3ci3zrotKQtyTNDJ28AC+j+BP5YVBdFSI3oVUhx1ot2NmmqH3pP4pByjmog==)
+  client_email: ENC(EvAyxZgB8XtiiClc6bQKwAxYq20wY/f1z+0wXuYHTjj558r7I5n5Z6nk99RnnVFsQaRYHTgRbceipOsKHpc+mZ34tBojyZJX)
+  client_id:  ENC(L/kuG/uook+pt8Bi3aSupfjInTq+PLK3jgnf1foOGuI=)
+  auth_uri: ENC(XGT3iYOVqBNkvIQcNalSD8h6hIa116fym5IkWE/DMXlE/34DlJpy6uSd/s87i0Y4//NwBJYTNdk=)
+  token_uri: ENC(0ozLVrhtKIRmk1rMq1vbOro8POwuYngnc/OX1EtznGAwUl2uMUtuzg3/1szetKGt)
+  auth_provider_x509_cert_url: ENC(tXhDWjbD4m7ALX1ZTb5+VlvlaQXUbq0jdAu7OWOpr9EhEuXM6vNV/O6v5qhNY/1leWal3O4SFxY=)
+  universe_domain: ENC(esswM69UFJcUe7LYn339mPn6tFKUvvU1


### PR DESCRIPTION
# 💡 Issue
- #125

# 🌱 Key changes
- [x] 매칭 점수를 score 기준으로 내림차순 정렬하여 SortedSet 캐싱
- [x] 매칭 점수 이벤트 클래스 내, MatchScore 변경 로직에도 동일한 캐싱 과정 적용
- [x] MatchScore 조회 시 캐싱되어 있는 정렬된 매칭 점수를 반환하도록 

# ✅ To Reviewers
이벤트 클래스 실행 확인을 위한 테스트 코드 추가했습니다. 
(설정 파일 정보 : 
- 설정 파일명 : .env.test.properties 
- 설정 파일 path : test/resources 
- 설정 파일 내용 : 팀 노션 `배포 관련 데이터` 페이지 안에 `테스트용 설정 파일` 페이지 확인해주세요!

# 📸 스크린샷
매칭 점수 조회 시 score 기준으로 내림차순 정렬된 list 반환
🔻 Postman Response 🔻
<img width="620" alt="스크린샷 2025-04-24 오후 5 20 14" src="https://github.com/user-attachments/assets/76788757-4c33-4755-953d-a77ecda8c7a8" />
